### PR TITLE
Add gemset to rvmrc

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm ree-1.8.7-2010.02
+rvm ree-1.8.7-2010.02@urbanairship --create


### PR DESCRIPTION
This commit adds a gemset to rvmrc. This stops the installation of the gem's dependencies in development from polluting the global ruby gemset.
