### PR TITLE
alias and delete scheduled push notifications

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,7 +48,7 @@ Batching push notification sends
 ```ruby
 notifications = [
   {
-    :schedule_for => [1.hour.from_now],
+    :schedule_for => [{ :alias => 'deadbeef', :scheduled_time => 1.hour.from_now }],   # assigning an alias to a scheduled push
     :device_tokens => ['DEVICE-TOKEN-ONE', 'DEVICE-TOKEN-TWO'],
     :aps => {:alert => 'You have a new message!', :badge => 1}
   },
@@ -62,8 +62,9 @@ notifications = [
 Urbanairship.batch_push notifications # => true
 ```
 
+
 Sending broadcast notifications
---------------------------------
+-------------------------------
 Urbanairship allows you to send a broadcast notification to all active registered device tokens for your app.
 
 ```ruby
@@ -94,4 +95,15 @@ Urbanairship.feedback 24.hours.ago # =>
 #     "device_token"=>"DEVICE-TOKEN-TWO"
 #   }
 # ]
+```
+
+Deleting scheduled notifications
+--------------------------------
+
+If you know the alias or id of a scheduled push notification then you can delete it from Urbanairship's queue and it will not be delivered.
+
+```ruby
+Urbanairship.delete_scheduled_push("123456789") # => true
+Urbanairship.delete_scheduled_push(123456789) # => true
+Urbanairship.delete_scheduled_push(:alias => "deadbeef") # => true
 ```

--- a/urbanairship.gemspec
+++ b/urbanairship.gemspec
@@ -2,8 +2,8 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'urbanairship'
-  s.version = '1.0.2'
-  s.date = '2011-07-14'
+  s.version = '1.0.3'
+  s.date = '2011-11-14'
   s.summary = 'A Ruby wrapper for the Urbanairship API'
   s.description = 'Urbanairship is a Ruby library for interacting with the Urbanairship (http://urbanairship.com) API.'
   s.homepage = 'http://github.com/groupon/urbanairship'


### PR DESCRIPTION
Our project has fickle users. We often need to delete a notification after it has been scheduled. Since the library doesn't currently return the "scheduled_notifications" portion of the API response, it is easiest just to include an alias while registering the push notification. We can reference the same alias to delete the push.

This should be fully backwards compatible and includes updated specs and README.
