### PR TITLE
Allowing arbitrary parameters to be passed to the API payload.

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -11,7 +11,6 @@ module Urbanairship
     Timer = Timeout
   end
 
-  VALID_PUSH_PARAMS = %w(device_tokens aliases tags schedule_for exclude_tokens aps)
   VALID_REGISTER_PARAMS = %w(alias)
 
   class << self
@@ -108,7 +107,7 @@ module Urbanairship
 
     def parse_push_options(hash = {})
       hash[:schedule_for] = hash[:schedule_for].map{|elem| process_scheduled_elem(elem)} unless hash[:schedule_for].nil?
-      hash.delete_if{|key, value| !VALID_PUSH_PARAMS.include?(key.to_s)}
+      hash
     end
 
     def log_request_and_response(request, response, time)

--- a/spec/urbanairship_spec.rb
+++ b/spec/urbanairship_spec.rb
@@ -303,9 +303,9 @@ describe Urbanairship do
       request_json['aps'].should == {'badge' => 10, 'alert' => 'Hi!', 'sound' => 'cat.caf'}
     end
 
-    it "excludes invalid parameters from the JSON payload" do
+    it "includes arbitrary parameters from the JSON payload" do
       Urbanairship.push(@valid_params.merge(:foo => 'bar'))
-      request_json['foo'].should be_nil
+      request_json['foo'].should == 'bar'
     end
 
     it "returns false if urbanairship responds with a non-200 response" do
@@ -398,10 +398,10 @@ describe Urbanairship do
       request_json[0]['aps'].should == {'badge' => 10, 'alert' => 'Hi!', 'sound' => 'cat.caf'}
     end
 
-    it "excludes invalid parameters from the JSON payload" do
+    it "include arbitrary parameters from the JSON payload" do
       @valid_params[0].merge!(:foo => 'bar')
       Urbanairship.batch_push(@valid_params)
-      request_json[0]['foo'].should be_nil
+      request_json[0]['foo'].should == 'bar'
     end
 
     it "returns false if urbanairship responds with a non-200 response" do
@@ -485,10 +485,10 @@ describe Urbanairship do
       request_json['aps'].should == {'badge' => 10, 'alert' => 'Hi!', 'sound' => 'cat.caf'}
     end
 
-    it "excludes invalid parameters from the JSON payload" do
+    it "includes arbitrary parameters from the JSON payload" do
       @valid_params[:foo] = 'bar'
       Urbanairship.broadcast_push(@valid_params)
-      request_json['foo'].should be_nil
+      request_json['foo'].should == 'bar'
     end
 
     it "returns false if urbanairship responds with a non-200 response" do


### PR DESCRIPTION
Just a minor change, to allow for full API usage with this gem.

Not sure if it makes sense to change the tests, like I do, or just delete them. You decice (obviously).

---

Push notifications, both iOS and Android, can have arbitrary parameters associated with them. To pass such an arbitrary parameter, use a key that isn't a part of the Urban Airship API, and it will be shipped with the push notification to the devices.

This is useful for passing arbitrary metadata along with the notification itself, such as the numeric ID of the record associated with a push notification, if any.

The documentation for this feature in the Urban Airship API can be found here: https://support.urbanairship.com/customer/portal/articles/60532-sending-custom-push-data
