### PR TITLE
Now throws an Unauthorized exception when UA returns 401 status code

### DIFF
--- a/spec/urbanairship_spec.rb
+++ b/spec/urbanairship_spec.rb
@@ -251,7 +251,7 @@ describe Urbanairship do
 
     it "raises an error when a push is done when authorization is invalid" do 
       Urbanairship.application_key = "bad_key"
-      lambda { 
+      lambda {
         Urbanairship.push(@valid_params) 
       }.should raise_error(Urbanairship::Error::Unauthorized)
     end
@@ -309,7 +309,7 @@ describe Urbanairship do
 
     it "returns false when the authorization is invalid" do
       Urbanairship.application_key = "bad_key"
-      lambda {       
+      lambda {
         Urbanairship.batch_push(@valid_params)
       }.should raise_error(Urbanairship::Error::Unauthorized)
     end


### PR DESCRIPTION
Not sure if you would want this as it might break existing installs but I thought I would open a request anyway...

Currently there is no way of knowing what errors are happening in the backend. When dealing with network api calls there are many points of failure. In a system I am working on I need to know if there is an authorization error or if there is a network error. This patch creates an auth error class and throws it on 401's.
