### PR TITLE
Attempting to call logger.error when logger is nil

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -73,7 +73,9 @@ module Urbanairship
         Urbanairship::Response.wrap(response)
       end
     rescue Timeout::Error
-      logger.error "Urbanairship request timed out after #{request_timeout} seconds: [#{http_method} #{request.path} #{request.body}]"
+      unless logger.nil?
+        logger.error "Urbanairship request timed out after #{request_timeout} seconds: [#{http_method} #{request.path} #{request.body}]"
+      end
       Urbanairship::Response.wrap(nil, :body => {:error => 'Request timeout'}, :code => '503')
     end
 

--- a/spec/urbanairship_spec.rb
+++ b/spec/urbanairship_spec.rb
@@ -453,6 +453,12 @@ describe Urbanairship do
       Urbanairship.logger = @logger
     end
 
+    it "does not attempt to log if logger is not set" do
+      Urbanairship.logger = nil
+      @logger.should_not_receive(:error).with(/Urbanairship request timed out/)
+      Urbanairship.register_device('new_device_token')
+    end
+
     it "uses a default request_timeout value of five seconds" do
       Urbanairship::Timer.should_receive(:timeout).with(5.0).and_raise(Timeout::Error)
       @logger.should_receive(:error).with(/Urbanairship request timed out/)


### PR DESCRIPTION
We are seeing this error when a request timeout occurs:

```
NoMethodError: undefined method `error' for nil:NilClass

[GEM_ROOT]/gems/urbanairship-2.0.0/lib/urbanairship.rb:71:in `rescue in do_request'
[GEM_ROOT]/gems/urbanairship-2.0.0/lib/urbanairship.rb:55:in `do_request'
[GEM_ROOT]/gems/urbanairship-2.0.0/lib/urbanairship.rb:35:in `push'
```

I noticed that the rescue handler was attempting to call `logger.error`, but we are not setting logger in our initializer (inside a Rails 3.1 app). We have remedied the issue by setting the logger.

However, I did notice that there was defensive code around this in the `log_request_and_response` method, so I've added something similar to the `do_request` method.
