### PR TITLE
Support Urbanairship.unregister_device for Android with :provider => :android

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -26,8 +26,12 @@ module Urbanairship
       end
     end
 
-    def unregister_device(device_token)
-      do_request(:delete, "/api/device_tokens/#{device_token}", :authenticate_with => :application_secret)
+    def unregister_device(device_token, options = {})
+      if (options[:provider] || @provider) == :android
+        do_request(:delete, "/api/apids/#{device_token}", :authenticate_with => :application_secret)
+      else
+        do_request(:delete, "/api/device_tokens/#{device_token}", :authenticate_with => :application_secret)
+      end
     end
 
     def delete_scheduled_push(param)

--- a/spec/urbanairship_spec.rb
+++ b/spec/urbanairship_spec.rb
@@ -162,6 +162,19 @@ describe Urbanairship do
       Urbanairship.application_key = "bad_key"
       Urbanairship.unregister_device("key_to_delete").success?.should == false
     end
+
+    it "uses the android interface if 'provider' configuration option is set to :android" do
+      Urbanairship.provider = :android
+      Urbanairship.unregister_device("new_device_token")
+      FakeWeb.last_request.path.should == "/api/apids/new_device_token"
+      Urbanairship.provider = nil
+    end
+
+    it "uses the android interface if 'provider' option is passed as :android" do
+      Urbanairship.unregister_device("new_device_token", :provider => :android)
+      FakeWeb.last_request.path.should == "/api/apids/new_device_token"
+    end
+
   end
 
   describe "::delete_scheduled_push" do


### PR DESCRIPTION
See : https://docs.urbanairship.com/display/DOCS/Server%3A+Android+Push+API

Allow passing in :provider => :android to make sure unregister_device
works and does not throw an error.

Calls:
DELETE /api/apids/<apid>

Not:
DELETE /api/device_tokens/<device_token>
