### PR TITLE
Allow :provider => :android to also be passed as option "provider" => "android" String pair.

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -19,7 +19,7 @@ module Urbanairship
     def register_device(device_token, options = {})
       body = parse_register_options(options).to_json
 
-      if (options[:provider] || @provider) == :android
+      if ( (options[:provider] || @provider) == :android ) || ( (options[:provider] || @provider) == 'android' )
         do_request(:put, "/api/apids/#{device_token}", :body => body, :authenticate_with => :application_secret)
       else
         do_request(:put, "/api/device_tokens/#{device_token}", :body => body, :authenticate_with => :application_secret)
@@ -27,7 +27,7 @@ module Urbanairship
     end
 
     def unregister_device(device_token, options = {})
-      if (options[:provider] || @provider) == :android
+      if ( (options[:provider] || @provider) == :android ) || ( (options[:provider] || @provider) == 'android' )
         do_request(:delete, "/api/apids/#{device_token}", :authenticate_with => :application_secret)
       else
         do_request(:delete, "/api/device_tokens/#{device_token}", :authenticate_with => :application_secret)

--- a/spec/urbanairship_spec.rb
+++ b/spec/urbanairship_spec.rb
@@ -398,17 +398,30 @@ shared_examples_for "an Urbanairship client" do
       FakeWeb.last_request.path.should == "/api/device_tokens/new_device_token"
     end
 
-    it "uses the android interface if 'provider' configuration option is set to :android" do
+    it "uses the android interface if 'provider' configuration option is set to :android Symbol" do
       subject.provider = :android
       subject.register_device("new_device_token")
       FakeWeb.last_request.path.should == "/api/apids/new_device_token"
       subject.provider = nil
     end
 
-    it "uses the android interface if 'provider' option is passed as :android" do
+    it "uses the android interface if 'provider' configuration option is set to 'android' String" do
+      subject.provider = 'android'
+      subject.register_device("new_device_token")
+      FakeWeb.last_request.path.should == "/api/apids/new_device_token"
+      subject.provider = nil
+    end
+
+    it "uses the android interface if :provider Symbol key is passed an :android Symbol value" do
       subject.register_device("new_device_token", :provider => :android)
       FakeWeb.last_request.path.should == "/api/apids/new_device_token"
     end
+
+    it "uses the android interface if 'provider' Symbol key is passed an 'android' String value" do
+      subject.register_device("new_device_token", :provider => "android")
+      FakeWeb.last_request.path.should == "/api/apids/new_device_token"
+    end
+
   end
 
   describe "::unregister_device" do
@@ -446,15 +459,27 @@ shared_examples_for "an Urbanairship client" do
       subject.unregister_device("key_to_delete").success?.should == false
     end
 
-    it "uses the android interface if 'provider' configuration option is set to :android" do
+    it "uses the android interface if 'provider' configuration option is set to :android Symbol" do
       subject.provider = :android
       subject.unregister_device("new_device_token")
       FakeWeb.last_request.path.should == "/api/apids/new_device_token"
       subject.provider = nil
     end
 
-    it "uses the android interface if 'provider' option is passed as :android" do
+    it "uses the android interface if 'provider' configuration option is set to 'android' String" do
+      subject.provider = 'android'
+      subject.unregister_device("new_device_token")
+      FakeWeb.last_request.path.should == "/api/apids/new_device_token"
+      subject.provider = nil
+    end
+
+    it "uses the android interface if :provider Symbol key is passed with an :android Symbol value" do
       subject.unregister_device("new_device_token", :provider => :android)
+      FakeWeb.last_request.path.should == "/api/apids/new_device_token"
+    end
+
+    it "uses the android interface if :provider Symbol key is passed with an 'android' String value" do
+      subject.unregister_device("new_device_token", :provider => "android")
       FakeWeb.last_request.path.should == "/api/apids/new_device_token"
     end
 


### PR DESCRIPTION
This allows the UrbanAirship gem to be used inside a Resque/Sidekiq job
which will silently convert the options Hash with Symbol values to
String values when the job args are serialized through Redis.

Without this, when we passed arguments to a Sidekiq job to indicate that the job should be processed in the context of an Android request it would fail due to the UrbanAirship gem was very strict in only accepting symbols.  This was a tricky to diagnose issue which would cause registration/unregister calls to fail since the iOS API was being incorrectly tried for Android tokens.
