### PR TITLE
Automatically truncate message if payload exceeds 256 bytes.

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -151,6 +151,7 @@ module Urbanairship
     end
 
     def parse_push_options(hash = {})
+      hash[:aliases] = hash[:aliases].map{|a| a.to_s} unless hash[:aliases].nil?
       hash[:schedule_for] = hash[:schedule_for].map{|elem| process_scheduled_elem(elem)} unless hash[:schedule_for].nil?
       hash
     end

--- a/spec/urbanairship_spec.rb
+++ b/spec/urbanairship_spec.rb
@@ -552,6 +552,11 @@ shared_examples_for "an Urbanairship client" do
       subject.master_secret = "my_master_secret2"
       subject.push.success?.should == false
     end
+
+    it "converts aliases to strints" do
+      subject.push(@valid_params.merge(:aliases => [:one, 2]))
+      request_json['aliases'].should == ['one', '2']
+    end
   end
 
   describe "::push_to_segment" do

--- a/spec/urbanairship_spec.rb
+++ b/spec/urbanairship_spec.rb
@@ -553,7 +553,7 @@ shared_examples_for "an Urbanairship client" do
       subject.push.success?.should == false
     end
 
-    it "converts aliases to strints" do
+    it "converts aliases to strings" do
       subject.push(@valid_params.merge(:aliases => [:one, 2]))
       request_json['aliases'].should == ['one', '2']
     end

--- a/urbanairship.gemspec
+++ b/urbanairship.gemspec
@@ -2,8 +2,8 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'urbanairship'
-  s.version = '2.3.2'
-  s.date = '2013-06-13'
+  s.version = '2.3.3'
+  s.date = '2013-06-28'
   s.summary = 'A Ruby wrapper for the Urban Airship API'
   s.description = 'Urbanairship is a Ruby library for interacting with the Urban Airship (http://urbanairship.com) API.'
   s.homepage = 'http://github.com/groupon/urbanairship'

--- a/urbanairship.gemspec
+++ b/urbanairship.gemspec
@@ -2,8 +2,8 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'urbanairship'
-  s.version = '2.3.0'
-  s.date = '2013-02-18'
+  s.version = '2.3.1'
+  s.date = '2013-03-18'
   s.summary = 'A Ruby wrapper for the Urban Airship API'
   s.description = 'Urbanairship is a Ruby library for interacting with the Urban Airship (http://urbanairship.com) API.'
   s.homepage = 'http://github.com/groupon/urbanairship'

--- a/urbanairship.gemspec
+++ b/urbanairship.gemspec
@@ -2,8 +2,8 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'urbanairship'
-  s.version = '2.3.1'
-  s.date = '2013-03-18'
+  s.version = '2.3.2'
+  s.date = '2013-06-13'
   s.summary = 'A Ruby wrapper for the Urban Airship API'
   s.description = 'Urbanairship is a Ruby library for interacting with the Urban Airship (http://urbanairship.com) API.'
   s.homepage = 'http://github.com/groupon/urbanairship'


### PR DESCRIPTION
I wish that this logic lived inside of UA's API. I suppose adding it to libraries is the next best thing.

Since APS only allows a 256 byte payload, automatically truncate the push notification alert message if the payload exceeds 256 bytes.