### PR TITLE
The error item of a response on timeout should be using string keys,

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -135,7 +135,7 @@ module Urbanairship
       unless logger.nil?
         logger.error "Urbanairship request timed out after #{request_timeout} seconds: [#{http_method} #{request.path} #{request.body}]"
       end
-      Urbanairship::Response.wrap(nil, :body => {:error => 'Request timeout'}, :code => '503')
+      Urbanairship::Response.wrap(nil, :body => {'error' => 'Request timeout'}, :code => '503')
     end
 
     def verify_configuration_values(*symbols)


### PR DESCRIPTION
to match the "error" response returned by Urban Airship

Otherwise, detecting errors will need something like :

```
    response = Urbanairship.push(payload)
    error    = response["error"] || response[:error]

```

Happy to add a spec if you think it's needed
