### PR TITLE
Get rspec examples relating to the GET 'device_tokens' method (added in a prior commit) to work .  Add 'device_token' method for obtaining information on a single device token.

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -89,6 +89,10 @@ module Urbanairship
       do_request(:post, "/api/tags/#{params[:tag]}", :body => {provider_field => {:remove => [params[:device_token]]}}.to_json, :authenticate_with => :master_secret)
     end
 
+    def device_token(device_token)
+      do_request(:get, "/api/device_tokens/#{device_token}/", :authenticate_with => :application_secret)
+    end
+
     def device_tokens
       do_request(:get, "/api/device_tokens/", :authenticate_with => :master_secret)
     end

--- a/spec/urbanairship_spec.rb
+++ b/spec/urbanairship_spec.rb
@@ -103,6 +103,11 @@ shared_examples_for "an Urbanairship client" do
     FakeWeb.register_uri(:get, /my_app_key\:my_master_secret\@go\.urbanairship.com\/api\/device_tokens\/$/, :status => ["200", "OK"], :body => '{"device_tokens":[{"device_token":"some_token_1", "active":true,"alias":"", "tags":["some_tag"]}, {"device_token":"some_token_2", "active":false, "alias":"", "tags":["some_tag","some_tag2"]}], "device_tokens_count":2, "active_device_tokens_count":1}')
     FakeWeb.register_uri(:get, /my_app_key2\:my_master_secret2\@go\.urbanairship.com\/api\/device_tokens\/$/, :status => ["400", "Bad Requst"])
 
+    #device_info
+    FakeWeb.register_uri(:get, /my_app_key\:my_app_secret\@go\.urbanairship.com\/api\/device_tokens\/valid_device_token/, :status => ["200", "OK"], :body => '{"device_token":"valid_device_token","last_registration":null,"tz":null,"tags":[],"alias":null,"quiettime":{"start":null,"end":null},"active":true,"badge":0}')
+    FakeWeb.register_uri(:get, /my_app_key\:my_app_secret\@go\.urbanairship.com\/api\/device_tokens\/invalid_device_token/, :status => ["404", "OK"])
+    FakeWeb.register_uri(:get, /bad_key\:my_app_secret\@go\.urbanairship.com\/api\/device_tokens\/valid_device_token/, :status => ["401", "Unauthorized"])
+
   end
 
   describe "configuration" do
@@ -783,6 +788,40 @@ shared_examples_for "an Urbanairship client" do
       subject.application_key = "my_app_key2"
       subject.master_secret = "my_master_secret2"
       subject.feedback(Time.now).success?.should == false
+    end
+  end
+
+  describe "::device_token" do
+    before(:each) do
+      subject.application_key = "my_app_key"
+      subject.application_secret = "my_app_secret"
+    end
+
+    it "raises an error if call is made without an app key and master secret configured" do
+      subject.application_key = nil
+      subject.application_secret = nil
+
+      lambda {
+        subject.device_token("asdf1234")
+      }.should raise_error(RuntimeError, "Must configure application_key, application_secret before making this request.")
+    end
+
+    it "uses app key and secret to sign the request" do
+      subject.device_token("valid_device_token")
+      FakeWeb.last_request['authorization'].should == "Basic #{Base64::encode64('my_app_key:my_app_secret').chomp}"
+    end
+
+    it "returns a hash as response from the Device Token List API with a device token" do
+      response = subject.device_token('valid_device_token')
+      response.code.should == "200"
+      response.success?.should == true
+      response.class.should == Hash
+    end
+
+    it "success? is false when the call doesn't return 200" do
+      subject.application_key = "bad_key"
+      subject.application_secret = "my_app_secret"
+      subject.device_token('valid_device_token').success?.should == false
     end
   end
 


### PR DESCRIPTION
The rspec examples for the previous commit (c5f8e78899), which added a method to retrieve a lsit of device tokens, were not working. Fixed.
