### PR TITLE
fix tags_for_device (/api/device_tokens/:device_token/tags route no longer used)

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -88,7 +88,8 @@ module Urbanairship
     end
 
     def tags_for_device(device_token)
-      do_request(:get, "/api/device_tokens/#{device_token}/tags/", :authenticate_with => :master_secret)
+      device_info = device_info(device_token)
+      { "tags" => device_info["tags"] }
     end
 
     def tag_device(params)


### PR DESCRIPTION
`tags_for device` currently returns a blank hash.
Investigating myself, the `/api/device_tokens/:device_token/tags` route returns a 404 when I cURL it myself.

This version grabs the tags from the device_info method and returns it in the same hash format as before.