### PR TITLE
Update urbanairship.gemspec

### DIFF
--- a/urbanairship.gemspec
+++ b/urbanairship.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/groupon/urbanairship'
   s.authors = ['Groupon, Inc.']
   s.email = ['rubygems@groupon.com']
-  s.files = FileList['README.markdown', 'LICENSE', 'Rakefile', 'lib/**/*.rb'].to_a
+  s.files = FileList['README.md', 'LICENSE', 'Rakefile', 'lib/**/*.rb'].to_a
   s.test_files = FileList['spec/**/*.rb'].to_a
 
   s.add_dependency 'json'


### PR DESCRIPTION
Should prevent error message urbanairship-ae77dd9d9984 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["README.markdown"] are not files
