### PR TITLE
Namespace usage matching the Python library

### DIFF
--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -1,5 +1,11 @@
 require 'urbanairship/version'
+require 'urbanairship/push/payload'
+require 'urbanairship/push/audience'
 
 module Urbanairship
-  # Your code goes here...
+  # Make these functions available in the
+  # `Urbanairship` namespace, as in the Python
+  # library.
+  extend Urbanairship::Push::Payload
+  extend Urbanairship::Push::Audience
 end

--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -1,11 +1,15 @@
-require 'urbanairship/version'
-require 'urbanairship/push/payload'
 require 'urbanairship/push/audience'
+require 'urbanairship/push/payload'
+require 'urbanairship/push/schedule'
+require 'urbanairship/push/push'
+
 
 module Urbanairship
   # Make these functions available in the
   # `Urbanairship` namespace, as in the Python
   # library.
-  extend Urbanairship::Push::Payload
   extend Urbanairship::Push::Audience
+  extend Urbanairship::Push::Payload
+  extend Urbanairship::Push::Schedule
+  extend Urbanairship::Push
 end

--- a/spec/lib/urbanairship/push/audience_spec.rb
+++ b/spec/lib/urbanairship/push/audience_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
-require 'urbanairship/push/audience'
-include Urbanairship::Push::Audience
+require 'urbanairship'
 
 describe Urbanairship do
+  UA = Urbanairship
+
   context 'audience selectors' do
     [
       [
@@ -68,7 +69,7 @@ describe Urbanairship do
       ]
     ].each do |selector, value, expected_result|
       it "can filter for '#{selector}'" do
-        actual_payload = send(selector, value)
+        actual_payload = UA.send(selector, value)
         expect(actual_payload).to eq expected_result
       end
     end
@@ -90,60 +91,60 @@ describe Urbanairship do
       [:mpns, '074e84a2-9ed9-4eee-9ca4-cc597bfdbef']
     ].each do |selector, value|
       it "raise an error if ##{selector}'s parameter is invalid" do
-        expect { send(selector, value) }.to raise_error ArgumentError
+        expect { UA.send(selector, value) }.to raise_error ArgumentError
       end
     end
   end
 
   context 'compound selectors' do
     it 'can create an OR' do
-      result = or_({ tag: 'foo' }, tag: 'bar')
+      result = UA.or_({ tag: 'foo' }, tag: 'bar')
       expect(result).to eq(or: [{ tag: 'foo' }, { tag: 'bar' }])
     end
 
     it 'can create an AND' do
-      result = and_({ tag: 'foo' }, tag: 'bar')
+      result = UA.and_({ tag: 'foo' }, tag: 'bar')
       expect(result).to eq(and: [{ tag: 'foo' }, { tag: 'bar' }])
     end
 
     it 'can create a NOT' do
-      result = not_(tag: 'foo')
+      result = UA.not_(tag: 'foo')
       expect(result).to eq(not: { tag: 'foo' })
     end
   end
 
   describe '#recent_date' do
     it 'produces a date range in days' do
-      expect(recent_date(days: 4)).to eq(recent: { days: 4 })
+      expect(UA.recent_date(days: 4)).to eq(recent: { days: 4 })
     end
 
     it 'produces a date range in hours' do
-      expect(recent_date(hours: 4)).to eq(recent: { hours: 4 })
+      expect(UA.recent_date(hours: 4)).to eq(recent: { hours: 4 })
     end
 
     it 'raises an error if passed multiple key/value pairs' do
       expect {
-        recent_date(hours: 1, minutes: 2)
+        UA.recent_date(hours: 1, minutes: 2)
       }.to raise_error ArgumentError
     end
 
     it 'raises an error if given an invalid resolution' do
       expect {
-        recent_date(eons: 7)
+        UA.recent_date(eons: 7)
       }.to raise_error ArgumentError
     end
   end
 
   describe '#absolute_date' do
     it 'produces a day-based range' do
-      result = absolute_date(resolution: :days,
+      result = UA.absolute_date(resolution: :days,
                              start: '2012-01-01',
                              the_end: '2012-01-05')
       expect(result).to eq(days: { start: '2012-01-01', end: '2012-01-05' })
     end
 
     it 'produces a week-based range' do
-      result = absolute_date(resolution: :weeks,
+      result = UA.absolute_date(resolution: :weeks,
                              start: '2012-01-01',
                              the_end: '2012-01-05')
       expect(result).to eq(weeks: { start: '2012-01-01', end: '2012-01-05' })
@@ -151,7 +152,7 @@ describe Urbanairship do
 
     it 'raises an error if given an invalid resolution' do
       expect {
-        absolute_date(resolution: :eons,
+        UA.absolute_date(resolution: :eons,
                       start: '2012-01-01',
                       the_end: '2012-01-05')
       }.to raise_error ArgumentError
@@ -164,12 +165,12 @@ describe Urbanairship do
     }
 
     it 'produces a location based on an id and date' do
-      payload = location(id: 'some_id', date: a_recent_date)
+      payload = UA.location(id: 'some_id', date: a_recent_date)
       expect(payload).to eq(location: { id: 'some_id', date: a_recent_date })
     end
 
     it 'produces a location from an alias and date' do
-      payload = location(us_zip: '97210', date: a_recent_date)
+      payload = UA.location(us_zip: '97210', date: a_recent_date)
       expect(payload).to eq(location: { us_zip: '97210', date: a_recent_date })
     end
   end

--- a/spec/lib/urbanairship/push/payload_spec.rb
+++ b/spec/lib/urbanairship/push/payload_spec.rb
@@ -1,47 +1,48 @@
 require 'spec_helper'
 
-require 'urbanairship/push/payload'
-include Urbanairship::Push::Payload
+require 'urbanairship'
 
 describe Urbanairship do
+  UA = Urbanairship
+
   describe '#interactive' do
     it 'must be given a "type"' do
       expect {
-        interactive(type: nil)
+        UA.interactive(type: nil)
       }.to raise_error ArgumentError
     end
 
     it 'does not require button actions' do
-      expect(interactive(type: 't')).to eq type: 't'
+      expect(UA.interactive(type: 't')).to eq type: 't'
     end
   end
 
   describe '#options' do
     it 'accepts an integer expiry' do
-      expect(options(expiry: 12_000)).to eq(expiry: 12_000)
+      expect(UA.options(expiry: 12_000)).to eq(expiry: 12_000)
     end
 
     it 'accepts a string date' do
       date = '2015-04-01T12:00:00'
-      expect(options(expiry: date)).to eq(expiry: date)
+      expect(UA.options(expiry: date)).to eq(expiry: date)
     end
   end
 
 
   describe '#notification' do
     it 'builds a simple text alert' do
-      expect(notification(alert: 'Hello')).to eq alert: 'Hello'
+      expect(UA.notification(alert: 'Hello')).to eq alert: 'Hello'
     end
 
     it 'requires a parameter' do
       expect {
-        notification
+        UA.notification
       }.to raise_error
     end
 
     context 'Android' do
       it 'builds a notification' do
-        payload = notification(android: android(
+        payload = UA.notification(android: android(
           alert: 'Hello',
           delay_while_idle: true,
           collapse_key: '123456',
@@ -73,7 +74,7 @@ describe Urbanairship do
 
     context 'iOS' do
       it 'builds a notification' do
-        payload = notification(ios: ios(
+        payload = UA.notification(ios: ios(
           alert: 'Hello',
           badge: '+1',
           sound: 'cat.caf',
@@ -105,7 +106,7 @@ describe Urbanairship do
       end
 
       it 'builds a notification with a key/value alert' do
-        payload = notification(ios: ios(
+        payload = UA.notification(ios: ios(
           alert: { foo: 'bar' },
           badge: '+1',
           sound: 'cat.caf',
@@ -137,12 +138,12 @@ describe Urbanairship do
       end
 
       it 'can handle Unicode' do
-        message = notification(ios: ios(alert: 'Paß auf!'))
+        message = UA.notification(ios: ios(alert: 'Paß auf!'))
         expect(message).to eq ios: { alert: 'Paß auf!' }
       end
 
       it 'handles the "content-available" attribute properly' do
-        message = notification(ios: ios(content_available: true))
+        message = UA.notification(ios: ios(content_available: true))
         expect(message).to eq ios: { 'content-available' => true }
       end
     end
@@ -150,7 +151,7 @@ describe Urbanairship do
 
     context 'Amazon' do
       it 'builds a notification' do
-        payload = notification(amazon: amazon(
+        payload = UA.notification(amazon: amazon(
           alert: 'Hello',
           title: 'My Title',
           consolidation_key: '123456',
@@ -182,13 +183,13 @@ describe Urbanairship do
 
     context 'Blackberry' do
       it 'sends "alerts" as plain text' do
-        payload = notification(blackberry: blackberry(alert: 'Hello'))
+        payload = UA.notification(blackberry: blackberry(alert: 'Hello'))
         expect(payload)
           .to eq blackberry: { body: 'Hello', content_type: 'text/plain' }
       end
 
       it 'can send html' do
-        payload = notification(blackberry: blackberry(
+        payload = UA.notification(blackberry: blackberry(
           body: 'Hello',
           content_type: 'text/html'
         ))
@@ -200,28 +201,28 @@ describe Urbanairship do
 
     context 'WNS' do
       it 'can send a simple text "alert"' do
-        payload = notification(wns: wns_payload(alert: 'Hello'))
+        payload = UA.notification(wns: wns_payload(alert: 'Hello'))
         expect(payload).to eq wns: { alert: 'Hello' }
       end
 
       it 'can send a key/value "toast"' do
-        payload = notification(wns: wns_payload(toast: { a_key: 'a_value' }))
+        payload = UA.notification(wns: wns_payload(toast: { a_key: 'a_value' }))
         expect(payload).to eq wns: { toast: { a_key: 'a_value' } }
       end
 
       it 'can send a key/value "tile"' do
-        payload = notification(wns: wns_payload(tile: { a_key: 'a_value' }))
+        payload = UA.notification(wns: wns_payload(tile: { a_key: 'a_value' }))
         expect(payload).to eq wns: { tile: { a_key: 'a_value' } }
       end
 
       it 'can send a key/value "badge"' do
-        payload = notification(wns: wns_payload(badge: { a_key: 'a_value' }))
+        payload = UA.notification(wns: wns_payload(badge: { a_key: 'a_value' }))
         expect(payload).to eq wns: { badge: { a_key: 'a_value' } }
       end
 
       it 'will only send one kind of notification at a time' do
         expect {
-          wns_payload(alert: 'Hello', tile: 'Foo')
+          UA.wns_payload(alert: 'Hello', tile: 'Foo')
         }.to raise_error ArgumentError
       end
     end
@@ -229,23 +230,23 @@ describe Urbanairship do
 
     context 'MPNS' do
       it 'can send a simple text "alert"' do
-        payload = notification(mpns: mpns_payload(alert: 'Hello'))
+        payload = UA.notification(mpns: mpns_payload(alert: 'Hello'))
         expect(payload).to eq mpns: { alert: 'Hello' }
       end
 
       it 'can send a key/value "toast"' do
-        payload = notification(mpns: mpns_payload(toast: { a_key: 'a_value' }))
+        payload = UA.notification(mpns: mpns_payload(toast: { a_key: 'a_value' }))
         expect(payload).to eq mpns: { toast: { a_key: 'a_value' } }
       end
 
       it 'can send a key/value "tile"' do
-        payload = notification(mpns: mpns_payload(tile: { a_key: 'a_value' }))
+        payload = UA.notification(mpns: mpns_payload(tile: { a_key: 'a_value' }))
         expect(payload).to eq mpns: { tile: { a_key: 'a_value' } }
       end
 
       it 'will only send one kind of notification at a time' do
         expect {
-          mpns_payload(alert: 'Hello', tile: 'Foo')
+          UA.mpns_payload(alert: 'Hello', tile: 'Foo')
         }.to raise_error ArgumentError
       end
     end
@@ -253,7 +254,7 @@ describe Urbanairship do
 
     context 'Rich Push' do
       it 'can send UTF-8 HTML' do
-        payload = message(
+        payload = UA.message(
           title: 'My Title',
           body: '<html>Körper des Dokumentes</html>',
           content_type: 'text/html',
@@ -272,14 +273,14 @@ describe Urbanairship do
       end
 
       it 'can send plain text' do
-        payload = message(title: 'My Title', body: 'My Body')
+        payload = UA.message(title: 'My Title', body: 'My Body')
         expect(payload).to eq title: 'My Title', body: 'My Body'
       end
     end
 
     describe '#device_types' do
       it 'supports the "all" option' do
-        expect(device_types(all_)).to eq 'all'
+        expect(UA.device_types(all_)).to eq 'all'
       end
     end
 

--- a/spec/lib/urbanairship/push/payload_spec.rb
+++ b/spec/lib/urbanairship/push/payload_spec.rb
@@ -42,7 +42,7 @@ describe Urbanairship do
 
     context 'Android' do
       it 'builds a notification' do
-        payload = UA.notification(android: android(
+        payload = UA.notification(android: UA.android(
           alert: 'Hello',
           delay_while_idle: true,
           collapse_key: '123456',
@@ -74,7 +74,7 @@ describe Urbanairship do
 
     context 'iOS' do
       it 'builds a notification' do
-        payload = UA.notification(ios: ios(
+        payload = UA.notification(ios: UA.ios(
           alert: 'Hello',
           badge: '+1',
           sound: 'cat.caf',
@@ -106,7 +106,7 @@ describe Urbanairship do
       end
 
       it 'builds a notification with a key/value alert' do
-        payload = UA.notification(ios: ios(
+        payload = UA.notification(ios: UA.ios(
           alert: { foo: 'bar' },
           badge: '+1',
           sound: 'cat.caf',
@@ -138,12 +138,12 @@ describe Urbanairship do
       end
 
       it 'can handle Unicode' do
-        message = UA.notification(ios: ios(alert: 'Paß auf!'))
+        message = UA.notification(ios: UA.ios(alert: 'Paß auf!'))
         expect(message).to eq ios: { alert: 'Paß auf!' }
       end
 
       it 'handles the "content-available" attribute properly' do
-        message = UA.notification(ios: ios(content_available: true))
+        message = UA.notification(ios: UA.ios(content_available: true))
         expect(message).to eq ios: { 'content-available' => true }
       end
     end
@@ -151,7 +151,7 @@ describe Urbanairship do
 
     context 'Amazon' do
       it 'builds a notification' do
-        payload = UA.notification(amazon: amazon(
+        payload = UA.notification(amazon: UA.amazon(
           alert: 'Hello',
           title: 'My Title',
           consolidation_key: '123456',
@@ -183,13 +183,13 @@ describe Urbanairship do
 
     context 'Blackberry' do
       it 'sends "alerts" as plain text' do
-        payload = UA.notification(blackberry: blackberry(alert: 'Hello'))
+        payload = UA.notification(blackberry: UA.blackberry(alert: 'Hello'))
         expect(payload)
           .to eq blackberry: { body: 'Hello', content_type: 'text/plain' }
       end
 
       it 'can send html' do
-        payload = UA.notification(blackberry: blackberry(
+        payload = UA.notification(blackberry: UA.blackberry(
           body: 'Hello',
           content_type: 'text/html'
         ))
@@ -201,22 +201,22 @@ describe Urbanairship do
 
     context 'WNS' do
       it 'can send a simple text "alert"' do
-        payload = UA.notification(wns: wns_payload(alert: 'Hello'))
+        payload = UA.notification(wns: UA.wns_payload(alert: 'Hello'))
         expect(payload).to eq wns: { alert: 'Hello' }
       end
 
       it 'can send a key/value "toast"' do
-        payload = UA.notification(wns: wns_payload(toast: { a_key: 'a_value' }))
+        payload = UA.notification(wns: UA.wns_payload(toast: { a_key: 'a_value' }))
         expect(payload).to eq wns: { toast: { a_key: 'a_value' } }
       end
 
       it 'can send a key/value "tile"' do
-        payload = UA.notification(wns: wns_payload(tile: { a_key: 'a_value' }))
+        payload = UA.notification(wns: UA.wns_payload(tile: { a_key: 'a_value' }))
         expect(payload).to eq wns: { tile: { a_key: 'a_value' } }
       end
 
       it 'can send a key/value "badge"' do
-        payload = UA.notification(wns: wns_payload(badge: { a_key: 'a_value' }))
+        payload = UA.notification(wns: UA.wns_payload(badge: { a_key: 'a_value' }))
         expect(payload).to eq wns: { badge: { a_key: 'a_value' } }
       end
 
@@ -230,17 +230,17 @@ describe Urbanairship do
 
     context 'MPNS' do
       it 'can send a simple text "alert"' do
-        payload = UA.notification(mpns: mpns_payload(alert: 'Hello'))
+        payload = UA.notification(mpns: UA.mpns_payload(alert: 'Hello'))
         expect(payload).to eq mpns: { alert: 'Hello' }
       end
 
       it 'can send a key/value "toast"' do
-        payload = UA.notification(mpns: mpns_payload(toast: { a_key: 'a_value' }))
+        payload = UA.notification(mpns: UA.mpns_payload(toast: { a_key: 'a_value' }))
         expect(payload).to eq mpns: { toast: { a_key: 'a_value' } }
       end
 
       it 'can send a key/value "tile"' do
-        payload = UA.notification(mpns: mpns_payload(tile: { a_key: 'a_value' }))
+        payload = UA.notification(mpns: UA.mpns_payload(tile: { a_key: 'a_value' }))
         expect(payload).to eq mpns: { tile: { a_key: 'a_value' } }
       end
 
@@ -280,7 +280,7 @@ describe Urbanairship do
 
     describe '#device_types' do
       it 'supports the "all" option' do
-        expect(UA.device_types(all_)).to eq 'all'
+        expect(UA.device_types(UA.all_)).to eq 'all'
       end
     end
 

--- a/spec/lib/urbanairship/push/scheduled_spec.rb
+++ b/spec/lib/urbanairship/push/scheduled_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-require 'urbanairship/push/schedule'
-include Urbanairship::Push::Schedule
-
+require 'urbanairship'
 
 describe Urbanairship do
+  UA = Urbanairship
+
   let(:a_time) { DateTime.new(2013, 1, 1, 12, 56) }
   let(:a_time_in_text) { '2013-01-01T12:56:00' }
 
   describe '#scheduled_time' do
     it 'creates a payload from a DateTime' do
-      payload = scheduled_time(a_time)
+      payload = UA.scheduled_time(a_time)
       expect(payload).to eq(scheduled_time: a_time_in_text)
     end
   end
 
   describe '#local_scheduled_time' do
     it 'creates a payload from a DateTime' do
-      payload = local_scheduled_time(a_time)
+      payload = UA.local_scheduled_time(a_time)
       expect(payload).to eq(local_scheduled_time: a_time_in_text)
     end
   end


### PR DESCRIPTION
Followed the Python library's conventions, and set up `Urbanairship` as the namespace to contain most of the functions. E.g.:

```ruby
require 'urbanairship'
UA = Urbanairship
payload = UA.scheduled_time(...)
```