### PR TITLE
Only use Ruby extensions if ActiveSupport missing

### DIFF
--- a/lib/ext/hash.rb
+++ b/lib/ext/hash.rb
@@ -1,5 +1,7 @@
-class Hash
-  def compact
-    keep_if { |_, value| !value.nil? }
+unless Hash.method_defined?(:compact)
+  class Hash
+    def compact
+      keep_if { |_, value| !value.nil? }
+    end
   end
 end

--- a/lib/ext/object.rb
+++ b/lib/ext/object.rb
@@ -1,5 +1,7 @@
-class Object
-  def try(method)
-    send method if respond_to? method
+unless Object.method_defined?(:try)
+  class Object
+    def try(method)
+      send method if respond_to? method
+    end
   end
 end


### PR DESCRIPTION
Overriding ActiveSupport's `Object#try` and `Hash#Compact` was surprising behavior to find inside a gem. It's possible that when in a Rails environment, the load order will use this gem's implementation of the two methods rather than the well tested implementations found in ActiveSupport.

This commit proposes only defining these extensions in the event that the methods have _not_ already been defined in something like ActiveSupport.

I would strongly recommend at the very least using the same method signature and implementation that has been defined in ActiveSupport for [`Object#try`](https://github.com/rails/rails/blob/cd2d3664e3b434d15b6c19e652befb386187642f/activesupport/lib/active_support/core_ext/object/try.rb#L62-L64) and [`Hash#compact`](https://github.com/rails/rails/blob/cd2d3664e3b434d15b6c19e652befb386187642f/activesupport/lib/active_support/core_ext/hash/compact.rb#L8-L10). Perhaps that can be done in a subsequent pull request.