### PR TITLE
Updates alias to coerce to string

### DIFF
--- a/lib/urbanairship/push/audience.rb
+++ b/lib/urbanairship/push/audience.rb
@@ -42,7 +42,7 @@ module Urbanairship
 
       # Select a single alias
       def alias(an_alias)
-        { alias: an_alias }
+        { alias: an_alias.to_s }
       end
 
       # Select a single segment using segment_id

--- a/spec/lib/urbanairship/push/audience_spec.rb
+++ b/spec/lib/urbanairship/push/audience_spec.rb
@@ -96,6 +96,14 @@ describe Urbanairship do
     end
   end
 
+  describe '#alias' do
+    let(:an_alias) { 42 }
+
+    it 'coerses the alias to a string before sending' do
+      expect(UA.alias(an_alias)).to eq({ alias: '42' })
+    end
+  end
+
   context 'compound selectors' do
     it 'can create an OR' do
       result = UA.or({ tag: 'foo' }, tag: 'bar')


### PR DESCRIPTION
The API appears to require that the "alias" value in the payload be a string. Unfortunately if a string is passed, you will receive an error similar to the following:

```
{
  "ok" => false,
  "error" => "Could not parse request body.",
  "error_code" => 40214,
  "details" => {
    "error"=>"Empty selector."
  },
  ...
}
```

This commit resolves that issue by coercing the parameter passed to the `alias` method into a string before including it into the payload.