### PR TITLE
Wrap blank payload with Array.wrap

### DIFF
--- a/lib/urbanairship/push/push.rb
+++ b/lib/urbanairship/push/push.rb
@@ -180,7 +180,7 @@ module Urbanairship
       # @return [Object] String Formatted PushResponse
       def format
         base = "Received [#{@status_code}] response code. \nHeaders: \tBody:\n"
-        payload.each do |key, value|
+        Array.wrap(payload).each do |key, value|
           safe_value = value.to_s || "None"
           base << "#{key}:\t#{safe_value}\n"
         end


### PR DESCRIPTION
Fixes error caused by blank payload being returned from `send_push`
```ruby

NoMethodError:
  undefined method `each' for "":String
  # /work/ruby-2.2.2@nasa/gems/urbanairship-3.0.2/lib/urbanairship/push/push.rb:183:in 'format'
  # /work/ruby-2.2.2@nasa/gems/urbanairship-3.0.2/lib/urbanairship/push/push.rb:49:in 'block in send_push'
  # /work/ruby-2.2.2@nasa/gems/urbanairship-3.0.2/lib/urbanairship/push/push.rb:49:in 'send_push'

```