### PR TITLE
Add optional group parameter when setting a push audience with tags

### DIFF
--- a/lib/urbanairship/push/audience.rb
+++ b/lib/urbanairship/push/audience.rb
@@ -37,8 +37,10 @@ module Urbanairship
       end
 
       # Select a single tag
-      def tag(tag)
-        { tag: tag }
+      def tag(tag, group: nil)
+        tag_params = { tag: tag }
+        tag_params[:group] = group unless group.nil?
+        tag_params
       end
 
       # Select a single alias

--- a/spec/lib/urbanairship/push/audience_spec.rb
+++ b/spec/lib/urbanairship/push/audience_spec.rb
@@ -58,6 +58,11 @@ describe Urbanairship do
         { tag: 'test' }
       ],
       [
+        :tag,
+        ['test', group: 'test-group'],
+        { tag: 'test', group: 'test-group' }
+      ],
+      [
         :alias,
         'test',
         { alias: 'test' }
@@ -69,7 +74,7 @@ describe Urbanairship do
       ]
     ].each do |selector, value, expected_result|
       it "can filter for '#{selector}'" do
-        actual_payload = UA.send(selector, value)
+        actual_payload = UA.send(selector, *value)
         expect(actual_payload).to eq expected_result
       end
     end


### PR DESCRIPTION
Add optional group parameter when setting a push audience with tags, to fix urbanairship/ruby-library#89