### PR TITLE
Remove Unirest dependency

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,8 +43,6 @@ Note that channels are preferred over ``device_token`` and ``apid``. See:
     p.device_types = UA.all
     p.send_push
 
-The library uses `unirest`_ for communication with the UA API.
-
 
 Development
 -----------
@@ -80,6 +78,5 @@ Indices and tables
 
 
 .. _channels: http://docs.urbanairship.com/topic-guides/channels.html
-.. _unirest: http://unirest.io/ruby.html
 .. _github: https://github.com/urbanairship/ruby-library
 .. _rspec: https://nose.readthedocs.org/en/latest/

--- a/lib/urbanairship/client.rb
+++ b/lib/urbanairship/client.rb
@@ -1,5 +1,5 @@
 require 'urbanairship'
-
+require 'urbanairship/http_client'
 
 module Urbanairship
     class Client
@@ -28,15 +28,8 @@ module Urbanairship
       def send_request(method: required('method'), url: required('url'), body: nil,
                        content_type: nil, encoding: nil)
 
-        uri       = URI(url)
-        http      = Net::HTTP.new(uri.host, uri.port)
-        request   = nil
-
-        http.use_ssl = true
-        http.read_timeout = 5
-
-        headers = {'User-agent' => 'UARubyLib/' + Urbanairship::VERSION}
-        headers['Accept'] = 'application/vnd.urbanairship+json; version=3'
+        headers = { "User-Agent"  => "UARubyLib/" + Urbanairship::VERSION }
+        headers["Accept"] = "application/vnd.urbanairship+json; version=3"
         headers['Content-type'] = content_type unless content_type.nil?
         headers['Content-Encoding'] = encoding unless encoding.nil?
 
@@ -49,36 +42,21 @@ module Urbanairship
 
         logger.debug(debug)
 
-        case method
-        when :get, "GET"
-          uri.query = URI.encode_www_form(body)
-          request = Net::HTTP::Get.new(uri, headers)
-        when :post, "POST"
-          request = Net::HTTP::Post.new(uri, headers)
-          request.body = body
-        when :put, "PUT"
-          request = Net::HTTP::Put.new(uri, headers)
-          request.body = body
-        when :delete, "DELETE"
-          request = Net::HTTP::Delete.new(uri, headers)
-          request.body = body
-        else
-          fail 'Method was not "GET" "POST" "PUT" or "DELETE"'
-        end
+        response = HttpClient.request(method, {
+          uri: url,
+          headers: headers,
+          auth: {
+            username: @key,
+            password: @secret,
+          },
+          parameters: body
+        })
 
-        request.basic_auth(@key, @secret)
+        logger.debug("Received #{response.code} response. Headers:\n\t#{response.headers}\nBody:\n\t#{response.body}")
 
-        response = http.request(request)
+        Response.check_code(response.code, response)
 
-        response_body     = JSON.parse(response.body)
-        response_code     = response.code.to_i
-        response_headers  = Hash[response.each_header.to_a]
-
-        logger.debug("Received #{response_code} response. Headers:\n\t#{response_headers}\nBody:\n\t#{response_body}")
-
-        Response.check_code(response_code, response)
-
-        {'body'=>response_body, 'code'=>response_code, 'headers'=>response_headers}
+        response
       end
 
       # Create a Push Object

--- a/lib/urbanairship/http_client.rb
+++ b/lib/urbanairship/http_client.rb
@@ -31,11 +31,11 @@ module Urbanairship
     class Request
       attr_reader :method, :uri, :headers, :parameters, :auth
 
-      def initialize(method, uri:, headers: {}, parameters: nil, auth: nil)
+      def initialize(method, uri:, headers: {}, parameters: {}, auth: nil)
         @method     = method.downcase.to_sym
         @uri        = URI(uri)
         @headers    = headers
-        @parameters = parameters
+        @parameters = parameters || {}
         @auth       = auth
         @request    = build_request
       end
@@ -67,7 +67,10 @@ module Urbanairship
       def build_request
         case method
         when :get
-          uri.query = URI.encode_www_form(parameters)
+          if parameters.any?
+            uri.query = URI.encode_www_form(parameters)
+          end
+
           Net::HTTP::Get.new(uri, headers)
         when :post
           req = Net::HTTP::Post.new(uri, headers)

--- a/lib/urbanairship/http_client.rb
+++ b/lib/urbanairship/http_client.rb
@@ -1,0 +1,89 @@
+module Urbanairship
+  class HttpClient
+
+    # Make an HTTP Request
+    def self.request(*args)
+      HttpClient::Request.new(*args).send_request
+    end
+
+    class Response
+      attr_reader :body, :code, :headers
+
+      def initialize(http_response)
+        @body    = parse_json(http_response.body)
+        @code    = http_response.code.to_i
+        @headers = http_response.each_header.to_a
+      end
+
+      def [](attribute)
+        send(attribute) if respond_to?(attribute)
+      end
+
+      private
+
+      def parse_json(body)
+        JSON.parse(body.to_s)
+      rescue JSON::ParserError
+        {}
+      end
+    end
+
+    class Request
+      attr_reader :method, :uri, :headers, :parameters, :auth
+
+      def initialize(method, uri:, headers: {}, parameters: nil, auth: nil)
+        @method     = method.downcase.to_sym
+        @uri        = URI(uri)
+        @headers    = headers
+        @parameters = parameters
+        @auth       = auth
+        @request    = build_request
+      end
+
+      def send_request
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.read_timeout = 5
+
+        headers.each do |header, value|
+          @request[header] = value
+        end
+
+        if auth
+          @request.basic_auth(auth[:username], auth[:password])
+        end
+
+        begin
+          response = http.request(@request)
+        rescue Net::HTTPRequestTimeOut
+          raise 'Request timeout'
+        end
+
+        HttpClient::Response.new(response)
+      end
+
+      private
+
+      def build_request
+        case method
+        when :get
+          uri.query = URI.encode_www_form(parameters)
+          Net::HTTP::Get.new(uri, headers)
+        when :post
+          req = Net::HTTP::Post.new(uri, headers)
+          req.body = parameters
+          req
+        when :put
+          req = Net::HTTP::Put.new(uri, headers)
+          req.body = parameters
+        when :delete
+          req = Net::HTTP::Delete.new(uri, headers)
+          req.body = parameters
+        else
+          fail 'Method was not "GET" "POST" "PUT" or "DELETE"'
+        end
+      end
+    end
+
+  end
+end

--- a/urbanairship.gemspec
+++ b/urbanairship.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'unirest', '~> 1.1', '>= 1.1.2'
-
   spec.add_development_dependency 'bundler', '~> 1'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'pry', '~> 0'


### PR DESCRIPTION
I was having a dependency version conflict with RestClient, which was being used by Unirest. I swapped it out for Net::HTTP for use in our application.

I wasn't sure if this is a desired change, but I figured I'd submit a PR and see. Then I found #86 and it seems like this is an issue affecting several others as well.