### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2.1
-  - 2.2.2
-script: bundle exec rspec
+  - 2.2.5
+  - 2.3.1

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,6 @@ Requirements
 
 We officially support the following Ruby versions::
 
-   2.1.10
    2.2.5
    2.3.1
 


### PR DESCRIPTION
Ruby 2.1.x is no longer supported by one of our development dependencies. I think it's best that there's parity between supported rubies for both dev/runtime environments. While we may be able to eliminate that dependency, it seems like ruby 2.1 is [near EOL](https://www.ruby-lang.org/en/downloads/).

Folks can still use ruby 2.1.x in a non-dev environment, we just won't officially claim to support it anymore.