### PR TITLE
Custom log filename and level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 /tmp/
 
 # App
-urbanairship.log
+*.log

--- a/lib/urbanairship/loggable.rb
+++ b/lib/urbanairship/loggable.rb
@@ -1,6 +1,5 @@
 require 'logger'
 
-
 module Urbanairship
   module Loggable
 
@@ -13,9 +12,13 @@ module Urbanairship
     end
 
     def self.create_logger
-      logger = Logger.new('urbanairship.log')
+      log_filename = ENV.fetch('URBANAIRSHIP_LOG_FILENAME', 'urbanairship.log')
+      log_level = ENV.fetch('URBANAIRSHIP_LOG_LEVEL', Logger::INFO)
+
+      logger = Logger.new(log_filename)
       logger.datetime_format = '%Y-%m-%d %H:%M:%S'
       logger.progname = 'Urbanairship'
+      logger.level = log_level
       logger
     end
   end

--- a/spec/lib/urbanairship/loggable_spec.rb
+++ b/spec/lib/urbanairship/loggable_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'urbanairship'
+
+describe Urbanairship::Loggable do
+  describe '#logger' do
+    it { expect(subject.logger).to be_an_instance_of(Logger) }
+  end
+
+  describe '.logger' do
+    it { expect(described_class.logger).to be_an_instance_of(Logger) }
+  end
+
+  describe '.create_logger' do
+    let(:logger) { described_class.create_logger }
+
+    it { expect(logger).to be_an_instance_of(Logger) }
+    it { expect(logger.progname).to eq 'Urbanairship' }
+    it { expect(logger.datetime_format).to eq '%Y-%m-%d %H:%M:%S' }
+
+    context 'without ENV vars' do
+      it 'initializes with default filename' do
+        expect(Logger).to receive(:new).with('urbanairship.log').and_call_original
+        logger
+      end
+
+      it 'has the log level as INFO' do
+        expect(logger.level).to eq(Logger::INFO)
+      end
+    end
+
+    context 'with ENV vars' do
+      before do
+        ENV['URBANAIRSHIP_LOG_FILENAME'] = 'urbanairship.test.log'
+        ENV['URBANAIRSHIP_LOG_LEVEL'] = 'DEBUG'
+      end
+
+      it 'initializes with custom filename' do
+        expect(Logger).to receive(:new).with('urbanairship.test.log').and_call_original
+        logger
+      end
+
+      it 'has the custom log level' do
+        expect(logger.level).to eq(Logger::DEBUG)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implementation to solve the problem of this issue: https://github.com/urbanairship/ruby-library/issues/96

Using the `URBANAIRSHIP_LOG_FILENAME` var, it's possible to set the folder as well.
Example:
`URBANAIRSHIP_LOG_FILENAME = 'log/urbanairship.log'`

Plus some tests that was missing 🌟 