### PR TITLE
Add config class for gem

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ In your app initialization, just create a file with a code something like this:
     >>> require 'urbanairship'
     >>> Urbanairship.configure do |config|
     >>>   config.log_path = '/path/to/your/logfile'
+    >>>   config.log_level = Logger::INFO
     >>> end
 
 
@@ -65,7 +66,7 @@ Available Configurations
 ========================
 
 - **log_path**: Allows to define the folder where the log file will be created (the default is nil).
-
+- **log_level**: Allows to define the log level and only messages at that level or higher will be printed.
 
 Usage
 =====

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,23 @@ OR install it yourself as::
     >>> gem install urbanairship
 
 
+Configuration
+=============
+
+In your app initialization, just create a file with a code something like this:
+
+    >>> require 'urbanairship'
+    >>> Urbanairship.configure do |config|
+    >>>   config.log_path = '/path/to/your/logfile'
+    >>> end
+
+
+Available Configurations
+========================
+
+- **log_path**: Allows to define the folder where the log file will be created (the default is nil).
+
+
 Usage
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ In your app initialization, just create a file with a code something like this:
     >>> require 'urbanairship'
     >>> Urbanairship.configure do |config|
     >>>   config.log_path = '/path/to/your/logfile'
-    >>>   config.log_level = Logger::INFO
+    >>>   config.log_level = Logger::WARN
     >>> end
 
 
@@ -66,7 +66,7 @@ Available Configurations
 ========================
 
 - **log_path**: Allows to define the folder where the log file will be created (the default is nil).
-- **log_level**: Allows to define the log level and only messages at that level or higher will be printed.
+- **log_level**: Allows to define the log level and only messages at that level or higher will be printed (the default is INFO).
 
 Usage
 =====

--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -6,6 +6,7 @@ require 'urbanairship/devices/segment'
 require 'urbanairship/devices/channel_uninstall'
 require 'urbanairship/client'
 require 'urbanairship/common'
+require 'urbanairship/configuration'
 require 'urbanairship/loggable'
 require 'urbanairship/util'
 require 'urbanairship/version'
@@ -25,4 +26,16 @@ module Urbanairship
   include Urbanairship::Devices
   include Urbanairship::Reports
   include Urbanairship::Push
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
 end

--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -29,13 +29,13 @@ module Urbanairship
 
   class << self
     attr_accessor :configuration
-  end
 
-  def self.configuration
-    @configuration ||= Configuration.new
-  end
+    def configuration
+      @configuration ||= Configuration.new
+    end
 
-  def self.configure
-    yield(configuration)
+    def configure
+      yield(configuration)
+    end
   end
 end

--- a/lib/urbanairship/configuration.rb
+++ b/lib/urbanairship/configuration.rb
@@ -4,7 +4,7 @@ module Urbanairship
 
     def initialize
       @log_path = nil
-      @log_level = Logger::DEBUG
+      @log_level = Logger::INFO
     end
   end
 end

--- a/lib/urbanairship/configuration.rb
+++ b/lib/urbanairship/configuration.rb
@@ -1,9 +1,10 @@
 module Urbanairship
   class Configuration
-    attr_accessor :log_path
+    attr_accessor :log_path, :log_level
 
     def initialize
       @log_path = nil
+      @log_level = Logger::DEBUG
     end
   end
 end

--- a/lib/urbanairship/configuration.rb
+++ b/lib/urbanairship/configuration.rb
@@ -1,0 +1,9 @@
+module Urbanairship
+  class Configuration
+    attr_accessor :log_path
+
+    def initialize
+      @log_path = nil
+    end
+  end
+end

--- a/lib/urbanairship/loggable.rb
+++ b/lib/urbanairship/loggable.rb
@@ -17,6 +17,7 @@ module Urbanairship
       logger = Logger.new(File.join(*log_uri))
       logger.datetime_format = '%Y-%m-%d %H:%M:%S'
       logger.progname = 'Urbanairship'
+      logger.level = Urbanairship.configuration.log_level
       logger
     end
   end

--- a/lib/urbanairship/loggable.rb
+++ b/lib/urbanairship/loggable.rb
@@ -13,7 +13,8 @@ module Urbanairship
     end
 
     def self.create_logger
-      logger = Logger.new('urbanairship.log')
+      log_uri = [Urbanairship.configuration.log_path, 'urbanairship.log'].compact
+      logger = Logger.new(File.join(*log_uri))
       logger.datetime_format = '%Y-%m-%d %H:%M:%S'
       logger.progname = 'Urbanairship'
       logger

--- a/spec/lib/urbanairship/configuration_spec.rb
+++ b/spec/lib/urbanairship/configuration_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'logger'
 require 'urbanairship/configuration'
 
 describe Urbanairship::Configuration do
@@ -11,6 +12,16 @@ describe Urbanairship::Configuration do
 
     it 'sets the path as is informed' do
       expect { config.log_path = '/tmp' }.to change(config, :log_path).from(nil).to('/tmp')
+    end
+  end
+
+  describe '#log_level' do
+    it 'initializes with the original value "debug level"' do
+      expect(config.log_level).to eq(Logger::DEBUG)
+    end
+
+    it 'sets the level as is informed' do
+      expect { config.log_level = Logger::INFO }.to change(config, :log_level).from(Logger::DEBUG).to(Logger::INFO)
     end
   end
 end

--- a/spec/lib/urbanairship/configuration_spec.rb
+++ b/spec/lib/urbanairship/configuration_spec.rb
@@ -16,12 +16,12 @@ describe Urbanairship::Configuration do
   end
 
   describe '#log_level' do
-    it 'initializes with the original value "debug level"' do
-      expect(config.log_level).to eq(Logger::DEBUG)
+    it 'initializes with the original value "info level"' do
+      expect(config.log_level).to eq(Logger::INFO)
     end
 
     it 'sets the level as is informed' do
-      expect { config.log_level = Logger::INFO }.to change(config, :log_level).from(Logger::DEBUG).to(Logger::INFO)
+      expect { config.log_level = Logger::WARN }.to change(config, :log_level).from(Logger::INFO).to(Logger::WARN)
     end
   end
 end

--- a/spec/lib/urbanairship/configuration_spec.rb
+++ b/spec/lib/urbanairship/configuration_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'urbanairship/configuration'
+
+describe Urbanairship::Configuration do
+  subject(:config) { described_class.new }
+
+  describe '#log_path' do
+    it 'initializes with the original value "nil"' do
+      expect(config.log_path).to be_nil
+    end
+
+    it 'sets the path as is informed' do
+      expect { config.log_path = '/tmp' }.to change(config, :log_path).from(nil).to('/tmp')
+    end
+  end
+end

--- a/spec/lib/urbanairship/loggable_spec.rb
+++ b/spec/lib/urbanairship/loggable_spec.rb
@@ -30,5 +30,23 @@ describe Urbanairship::Loggable do
         expect(logger.instance_variable_get(:@logdev).filename).to eq('/tmp/urbanairship.log')
       end
     end
+
+    context 'when no log level is informed' do
+      it 'defines the log level with the default logger log level' do
+        expect(logger.level).to eq(Logger::DEBUG)
+      end
+    end
+
+    context 'when a log path is informed' do
+      before do
+        Urbanairship.configure do |config|
+          config.log_level = Logger::WARN
+        end
+      end
+
+      it 'defines the log level with the passed value' do
+        expect(logger.level).to eq(Logger::WARN)
+      end
+    end
   end
 end

--- a/spec/lib/urbanairship/loggable_spec.rb
+++ b/spec/lib/urbanairship/loggable_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'urbanairship'
+
+describe Urbanairship::Loggable do
+  describe '.create_logger' do
+    subject(:logger) { described_class.create_logger }
+
+    it 'defines the "datetime_format"' do
+      expect(logger.datetime_format).to eq('%Y-%m-%d %H:%M:%S')
+    end
+
+    it 'defines the "progname"' do
+      expect(logger.progname).to eq('Urbanairship')
+    end
+
+    context 'when no log path is informed' do
+      it 'defines the log file with only filename' do
+        expect(logger.instance_variable_get(:@logdev).filename).to eq('urbanairship.log')
+      end
+    end
+
+    context 'when a log path is informed' do
+      before do
+        Urbanairship.configure do |config|
+          config.log_path = '/tmp'
+        end
+      end
+
+      it 'defines the log file with the log path' do
+        expect(logger.instance_variable_get(:@logdev).filename).to eq('/tmp/urbanairship.log')
+      end
+    end
+  end
+end

--- a/spec/lib/urbanairship/loggable_spec.rb
+++ b/spec/lib/urbanairship/loggable_spec.rb
@@ -33,7 +33,7 @@ describe Urbanairship::Loggable do
 
     context 'when no log level is informed' do
       it 'defines the log level with the default logger log level' do
-        expect(logger.level).to eq(Logger::DEBUG)
+        expect(logger.level).to eq(Logger::INFO)
       end
     end
 

--- a/spec/lib/urbanairship_spec.rb
+++ b/spec/lib/urbanairship_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'urbanairship'
+
+describe Urbanairship do
+  describe '.configure' do
+    it 'defines the "log_path"' do
+      Urbanairship.configure do |config|
+        config.log_path = '/tmp'
+      end
+
+      expect(Urbanairship.configuration.log_path).to eq('/tmp')
+    end
+  end
+end
+

--- a/spec/lib/urbanairship_spec.rb
+++ b/spec/lib/urbanairship_spec.rb
@@ -10,6 +10,14 @@ describe Urbanairship do
 
       expect(Urbanairship.configuration.log_path).to eq('/tmp')
     end
+
+    it 'defines the "log_level"' do
+      Urbanairship.configure do |config|
+        config.log_level = Logger::WARN
+      end
+
+      expect(Urbanairship.configuration.log_level).to eq(Logger::WARN)
+    end
   end
 end
 


### PR DESCRIPTION
Looking for this issue https://github.com/urbanairship/ruby-library/issues/96 i've built a way to make the gem configurable.

Starting from log parameters. But we can use this structure do make anything we could do as configurable options.

The way to use is very simple.
In a Rails app, for example, we can create a file in `config/initializers/urbanairship.rb` with the following content.

```rb
Urbanairship.configure do |config|
  config.log_path = File.join(Rails.root, 'log')
  config.log_level = Logger::INFO
end
```

To do this, I'm based on these articles:
https://robots.thoughtbot.com/mygem-configure-block
http://lizabinante.com/blog/creating-a-configurable-ruby-gem/