### PR TITLE
Fix ScheduledPush.from_url

### DIFF
--- a/lib/urbanairship/push/push.rb
+++ b/lib/urbanairship/push/push.rb
@@ -98,12 +98,14 @@ module Urbanairship
       # @return [Object] Scheduled Push Object
       def self.from_url(client: required('client'), url: required('url'))
         scheduled_push = ScheduledPush.new(client)
-        response_body = client.send_request(
+        response_payload = client.send_request(
           method: 'GET',
           body: nil,
           url: url
         )
-        payload = JSON.load(response_body)
+
+        response_json = JSON.load(response_payload.to_json)
+        payload = response_json['body']
 
         p = Push.new(client)
         p.audience = payload['push']['audience']


### PR DESCRIPTION
When trying to create a ScheduledPush using the schedule_url of a notification the library was failing because the response was changed in the API.

---

Steps to reproduce:

```
notification_schedule_url = "https://go.urbanairship.com/api/schedules/XXXXXXXX-XXXX-..."
client = Urbanairship::Client.new(key: ENV['UA_APP_KEY'], secret: ENV['UA_APP_MASTER_SECRET'])
Urbanairship::Push::ScheduledPush.from_url(client: client, url: notification_schedule_url)
```