### PR TITLE
Add request timeout option on configs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ In your app initialization, you can do something like the following:
     >>> Urbanairship.configure do |config|
     >>>   config.log_path = '/path/to/your/logfile'
     >>>   config.log_level = Logger::WARN
+    >>>   config.timeout = 60
     >>> end
 
 
@@ -61,6 +62,7 @@ Available Configurations
 
 - **log_path**: Allows to define the folder where the log file will be created (the default is nil).
 - **log_level**: Allows to define the log level and only messages at that level or higher will be printed (the default is INFO).
+- **timeout**: Allows to define the request timeout in seconds (the default is 5).
 
 
 Usage

--- a/lib/urbanairship/client.rb
+++ b/lib/urbanairship/client.rb
@@ -63,7 +63,7 @@ module Urbanairship
           user: @key,
           password: @secret,
           payload: body,
-          timeout: 5
+          timeout: Urbanairship.configuration.timeout
         )
 
         logger.debug("Received #{response.code} response. Headers:\n\t#{response.headers}\nBody:\n\t#{response.body}")

--- a/lib/urbanairship/configuration.rb
+++ b/lib/urbanairship/configuration.rb
@@ -1,10 +1,11 @@
 module Urbanairship
   class Configuration
-    attr_accessor :log_path, :log_level
+    attr_accessor :log_path, :log_level, :timeout
 
     def initialize
       @log_path = nil
       @log_level = Logger::INFO
+      @timeout = 5
     end
   end
 end

--- a/spec/lib/urbanairship/configuration_spec.rb
+++ b/spec/lib/urbanairship/configuration_spec.rb
@@ -24,4 +24,14 @@ describe Urbanairship::Configuration do
       expect { config.log_level = Logger::WARN }.to change(config, :log_level).from(Logger::INFO).to(Logger::WARN)
     end
   end
+
+  describe '#timeout' do
+    it 'initializes with the original value "5"' do
+      expect(config.timeout).to eq(5)
+    end
+
+    it 'sets the request timeout as is informed' do
+      expect { config.timeout = 60 }.to change(config, :timeout).from(5).to(60)
+    end
+  end
 end

--- a/spec/lib/urbanairship_spec.rb
+++ b/spec/lib/urbanairship_spec.rb
@@ -18,6 +18,14 @@ describe Urbanairship do
 
       expect(Urbanairship.configuration.log_level).to eq(Logger::WARN)
     end
+
+    it 'defines the request timeout' do
+      Urbanairship.configure do |config|
+        config.timeout = 60
+      end
+
+      expect(Urbanairship.configuration.timeout).to eq(60)
+    end
   end
 end
 


### PR DESCRIPTION
### What does this do and why?
As read on the UrbanAirship docs: "Setting a timeout limit of 60 seconds can result in higher success rates when accessing our API during extremely high loads." but how to do that?! 
So, this PR adds the option to change the request timeout using the UrbanAirship configurations.

For example:
```ruby
Urbanairship.configure do |config|
  config.timeout = 60
end
```

### Testing
- [x] I wrote tests covering these changes

* I've tested for Ruby versions:
- [x] 2.2.5
- [x] 2.3.1
- [x] 2.4.0