### PR TITLE
[LIBS-61] Remove support for feedback APIs and device token count

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,10 @@
 --------------------
+5.0.0
+--------------------
+- Removing support for Feedback API (EOL July 2018)
+- Removing support for Device Token Count (also EOL in 2018)
+
+--------------------
 4.1.1
 --------------------
 - Added configuration value for timeout.

--- a/docs/devices.rst
+++ b/docs/devices.rst
@@ -37,26 +37,6 @@ Device metadata is fetched for a specific channel by using
     channel_info = channel_client.lookup(uuid: 'uuid')
     puts(channel_info)
 
-Feedback
---------
-
-Feedback returns a list of dictionaries of device tokens/APIDs that the
-respective push provider has told us are uninstalled since the given
-timestamp. For more information, see `the API documentation for feedback
-<http://docs.urbanairship.com/api/ua.html#feedback>`_
-
-.. code-block:: ruby
-
-    require 'urbanairship'
-    require 'time'
-    UA = Urbanairship
-    airship = UA::Client.new(key:'application_key', secret:'master_secret')
-    since = (Time.now.utc - (60 * 60 * 24 * 3)).iso8601
-    feedback = UA::Feedback.new(client: airship)
-    tokens = feedback.device_token(since: since)
-    apids = feedback.apid(since: since)
-
-
 Device Token Lookup
 -------------------
 
@@ -88,21 +68,6 @@ Get a list of iOS device tokens for the application:
     device_token_list.each do |token|
         puts(token)
     end
-
-
-Device Token Count
-------------------
-
-Get the total iOS device tokens registered to the application.
-
-.. code-block:: ruby
-
-    require 'urbanairship'
-
-    UA = Urbanairship
-    airship = UA::Client.new(key:'application_key', secret:'master_secret')
-    device_token_list = UA::DeviceTokenList.new(client: airship)
-    puts(device_token_list.count)
 
 
 APID Lookup

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -11,8 +11,6 @@ module Urbanairship
     DEVICE_TOKEN_URL = BASE_URL + '/device_tokens/'
     APID_URL = BASE_URL + '/apids/'
     PUSH_URL = BASE_URL + '/push/'
-    DT_FEEDBACK_URL = BASE_URL + '/device_tokens/feedback/'
-    APID_FEEDBACK_URL = BASE_URL + '/apids/feedback/'
     SCHEDULES_URL = BASE_URL + '/schedules/'
     SEGMENTS_URL = BASE_URL + '/segments/'
     NAMED_USER_URL = BASE_URL + '/named_users/'

--- a/lib/urbanairship/devices/devicelist.rb
+++ b/lib/urbanairship/devices/devicelist.rb
@@ -30,34 +30,6 @@ module Urbanairship
       end
     end
 
-    class Feedback
-      include Urbanairship::Common
-      include Urbanairship::Loggable
-
-      def initialize(client: required('client'))
-        @client = client
-      end
-
-      def device_token(since: required('device token'))
-        url = DT_FEEDBACK_URL + '?since=' + since
-        get_feedback(url: url)
-      end
-
-      def apid(since: required('since'))
-        url = APID_FEEDBACK_URL + '?since=' + since
-        get_feedback(url: url)
-      end
-
-      def get_feedback(url: required('url'))
-        response = @client.send_request(
-            method: 'GET',
-            url: url
-        )
-        logger.info("Requested feedback at url #{url}")
-        response
-      end
-    end
-
     class DeviceToken
       include Urbanairship::Common
       include Urbanairship::Loggable
@@ -86,15 +58,6 @@ module Urbanairship
         super(client: client)
         @next_page = DEVICE_TOKEN_URL
         @data_attribute = 'device_tokens'
-      end
-
-      def count
-        resp = @client.send_request(
-          method: 'GET',
-          url: DEVICE_TOKEN_URL + 'count/'
-        )
-        logger.info("Retrieved count of Device Token List.")
-        resp
       end
     end
 

--- a/spec/lib/urbanairship/devices/device_info_spec.rb
+++ b/spec/lib/urbanairship/devices/device_info_spec.rb
@@ -107,61 +107,6 @@ describe Urbanairship::Devices do
     end
   end
 
-  describe Urbanairship::Devices::Feedback do
-    feedback = UA::Feedback.new(client: airship)
-
-    describe '#device_token' do
-      it 'can get the device_list' do
-        device_response = {
-            'body' => [
-                {
-                    'device_token' => '12341234',
-                    'marked_inactive_on' => '2015-08-01',
-                    'alias' => 'bob'
-                },
-                {
-                    'device_token' => '43214321',
-                    'marked_inactive_on' => '2015-08-03',
-                    'alias' => 'alice'
-                }
-            ],
-            'code' => '200'
-        }
-
-        allow(airship).to receive(:send_request).and_return(device_response)
-        since = (Time.new.utc - 60 * 70 * 24 * 3).iso8601 # Get tokens deactivated since 3 days ago
-        response = feedback.device_token(since: since)
-        expect(response).to eq device_response  
-      end
-    end
-
-    describe '#apid' do
-      it 'can get the apids' do
-        device_response = {
-            'body' => [
-                {
-                    'apid' => '12341234',
-                    'gcm_registration_id' => nil,
-                    'marked_inactive_on' => '2015-08-01',
-                    'alias' => 'bob'
-                },
-                {
-                    'apid' => '43214321',
-                    'gcm_registration_id' => nil,
-                    'marked_inactive_on' => '2015-08-03',
-                    'alias' => 'alice'
-                }
-            ],
-            'code' => '200'
-        }
-        allow(airship).to receive(:send_request).and_return(device_response)
-        since = (Time.new.utc - 60 * 70 * 24 * 3).iso8601 # Get apids deactivated since 3 days ago
-        response = feedback.apid(since: since)
-        expect(response).to eq device_response
-      end
-    end
-  end
-
   describe Urbanairship::Devices::DeviceToken do
     device_token = UA::DeviceToken.new(client: airship)
 
@@ -236,20 +181,6 @@ describe Urbanairship::Devices do
         expect(token).to eq(t)
       end
       expect(instantiated_list.size).to eq(6)
-    end
-
-    it 'can return the list count' do
-      expected_resp = {
-          'body' => {
-              'active_device_tokens_count' => 100,
-              'device_tokens_count' => 140
-          },
-          'code' => 200
-      }
-      allow(airship).to receive(:send_request).and_return(expected_resp)
-      device_token_list = UA::DeviceTokenList.new(client: airship)
-      count = device_token_list.count
-      expect(count).to eq(expected_resp)
     end
   end
 


### PR DESCRIPTION
### What does this do and why?
https://urbanairship.atlassian.net/browse/LIBS-61 - removes feedback API and device token count API

### Additional notes for reviewers
n/a

### Testing
- [x] I deleted tests covering these changes

* I've tested for Ruby versions:

- [x] 2.2.5
- [x] 2.3.1
- [x] 2.3.5

### Screenshots
![Fire](https://cdn.thisiswhyimbroke.com/images/mystic-fire.gif)

