### PR TITLE
Use passed in device_type variable instead of non-existent instance v…

### DIFF
--- a/lib/urbanairship/devices/named_user.rb
+++ b/lib/urbanairship/devices/named_user.rb
@@ -19,7 +19,7 @@ module Urbanairship
 
         payload = {}
         payload['channel_id'] = channel_id
-        payload['device_type'] = @device_type unless @device_type.nil?
+        payload['device_type'] = device_type unless device_type.nil?
         payload['named_user_id'] = @named_user_id
 
         response = @client.send_request(
@@ -35,7 +35,7 @@ module Urbanairship
       def disassociate(channel_id: required('channel_id'), device_type: nil)
         payload = {}
         payload['channel_id'] = channel_id
-        payload['device_type'] = @device_type unless @device_type.nil?
+        payload['device_type'] = device_type unless device_type.nil?
         payload['named_user_id'] = @named_user_id unless @named_user_id.nil?
         response = @client.send_request(
           method: 'POST',


### PR DESCRIPTION
### What does this do and why?

Uses the passed in device_type string instead of the unset instance variable that is currently used in NamedUser.associate and NamedUser.disassociate.

Before this, attempting to associate a mobile channel ID for iOS devices resulted in a 404

https://github.com/urbanairship/ruby-library/issues/113

### Additional notes for reviewers
* If applicable

### Testing
- [ ] I wrote tests covering these changes

* I've tested for Ruby versions:

- [ ] 2.2.5
- [ ] 2.3.1
- [ x ] 2.4.4

### Urban Airship Contribution Agreement
https://docs.urbanairship.com/contribution-agreement/

- [ x ] I've filled out and signed UA's contribution agreement form.

### Screenshots
* If applicable
