### PR TITLE
Add Named Users Uninstall API Client

### DIFF
--- a/lib/urbanairship/devices/named_user.rb
+++ b/lib/urbanairship/devices/named_user.rb
@@ -83,5 +83,30 @@ module Urbanairship
         @data_attribute = 'named_users'
       end
     end
+
+    class NamedUserUninstaller
+      include Urbanairship::Common
+      include Urbanairship::Loggable
+      attr_accessor :named_user_ids
+
+      def initialize(client: required('client'))
+        @client = client
+        @named_user_ids =  nil
+      end
+
+      def uninstall
+        payload = {}
+        payload['named_user_id'] = @named_user_ids
+
+        response = @client.send_request(
+          method: 'POST',
+          body: JSON.dump(payload),
+          url: NAMED_USER_URL + '/uninstall',
+          content_type: 'application/json'
+        )
+        logger.info { "Uninstalled named_user_ids #{@named_user_ids} " }
+        response
+      end
+    end
   end
 end

--- a/spec/lib/urbanairship/devices/named_user_spec.rb
+++ b/spec/lib/urbanairship/devices/named_user_spec.rb
@@ -235,4 +235,27 @@ describe Urbanairship::Devices do
     end
   end
 
+  describe Urbanairship::Devices::NamedUserUninstaller do
+    let(:expected_resp) do
+      {
+        'body' => {
+          'ok' => true
+        },
+        'code' => 200
+      }
+    end
+    let(:named_user_uninstaller) { described_class.new(client: airship) }
+    subject { named_user_uninstaller.uninstall }
+
+    describe '#uninstall' do
+      before do
+        named_user_uninstaller.named_user_ids = ['user']
+        allow(airship).to receive(:send_request).and_return(expected_resp)
+      end
+
+      it 'uninstall named_users' do
+        expect(subject).to eq(expected_resp)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What does this do and why?

Added because [Named User uninstall API](https://docs.urbanairship.com/api/ua/#operation/api/named_users/uninstall/post) Client was not in gem

### Testing
- [x] I wrote tests covering these changes

* I've tested for Ruby versions:

- [x] 2.2.5
- [x] 2.3.1

### Urban Airship Contribution Agreement
https://docs.urbanairship.com/contribution-agreement/

- [x] I've filled out and signed UA's contribution agreement form.

