### PR TITLE
Allow to use a custom logger

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,14 @@ In your app initialization, you can do something like the following:
     >>>   config.timeout = 60
     >>> end
 
+If you want to use a custom logger (e.g Rails.logger), you can do:
+
+    >>> require 'urbanairship'
+    >>> Urbanairship.configure do |config|
+    >>>   config.custom_logger = Rails.logger
+    >>>   config.log_level = Logger::WARN
+    >>>   config.timeout = 60
+    >>> end
 
 Available Configurations
 ------------------------

--- a/lib/urbanairship/configuration.rb
+++ b/lib/urbanairship/configuration.rb
@@ -1,8 +1,9 @@
 module Urbanairship
   class Configuration
-    attr_accessor :log_path, :log_level, :timeout
+    attr_accessor :custom_logger, :log_path, :log_level, :timeout
 
     def initialize
+      @custom_logger = nil
       @log_path = nil
       @log_level = Logger::INFO
       @timeout = 5

--- a/lib/urbanairship/loggable.rb
+++ b/lib/urbanairship/loggable.rb
@@ -1,15 +1,13 @@
 require 'logger'
 
-
 module Urbanairship
   module Loggable
-
     def logger
       Loggable.logger
     end
 
     def self.logger
-      @logger ||= Loggable.create_logger
+      @logger ||= Urbanairship.configuration.custom_logger || Loggable.create_logger
     end
 
     def self.create_logger

--- a/spec/lib/urbanairship/configuration_spec.rb
+++ b/spec/lib/urbanairship/configuration_spec.rb
@@ -5,6 +5,16 @@ require 'urbanairship/configuration'
 describe Urbanairship::Configuration do
   subject(:config) { described_class.new }
 
+  describe '#custom_logger' do
+    it 'initializes with the original value "nil"' do
+      expect(config.custom_logger).to be_nil
+    end
+
+    it 'sets the lib logger as the custom logger' do
+      expect { config.custom_logger = Logger.new(STDOUT) }.to change(config, :custom_logger).from(nil).to(an_instance_of(Logger))
+    end
+  end
+
   describe '#log_path' do
     it 'initializes with the original value "nil"' do
       expect(config.log_path).to be_nil

--- a/spec/lib/urbanairship/loggable_spec.rb
+++ b/spec/lib/urbanairship/loggable_spec.rb
@@ -2,6 +2,33 @@ require 'spec_helper'
 require 'urbanairship'
 
 describe Urbanairship::Loggable do
+  describe '.logger' do
+    before do
+      described_class.instance_variable_set(:@logger, nil)
+      Urbanairship.configure do |config|
+        config.custom_logger = custom_logger
+      end
+    end
+
+    context 'when there is a custom_logger' do
+      let(:custom_logger) { Logger.new(STDOUT) }
+
+      it 'uses the custom_logger' do
+        expect(described_class).not_to receive(:create_logger)
+        expect(described_class.logger).to eq(Urbanairship.configuration.custom_logger)
+      end
+    end
+
+    context 'when there is no custom_logger' do
+      let(:custom_logger) { nil }
+
+      it 'uses the default lib logger' do
+        expect(described_class).to receive(:create_logger).and_call_original
+        expect(described_class.logger.instance_variable_get(:@logdev).filename).to eq('urbanairship.log')
+      end
+    end
+  end
+
   describe '.create_logger' do
     subject(:logger) { described_class.create_logger }
 

--- a/urbanairship.gemspec
+++ b/urbanairship.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rest-client', '>= 1.4', '< 4.0'
 
-  spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency 'bundler', '>= 1'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'pry', '~> 0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
### What does this do and why?

The current implementation forces the log to be written in a disk file.
As I need to log in a stream via STDOUT, I created a configuration that allows the UA lib to set a custom logger of any kind (e.g. STDOUT logger, ActiveSupport's tagged logger).

### Testing
- [x] I wrote tests covering these changes

### Urban Airship Contribution Agreement
https://docs.urbanairship.com/contribution-agreement/

- [x] I've filled out and signed UA's contribution agreement form.