### PR TITLE
Sending a request with Auth Token instead of Basic Auth.

### DIFF
--- a/lib/urbanairship/client.rb
+++ b/lib/urbanairship/client.rb
@@ -13,10 +13,12 @@ module Urbanairship
       #
       # @param [Object] key Application Key
       # @param [Object] secret Application Secret
+      # @param [String] token Application Auth Token (for custom events endpoint)
       # @return [Object] Client
-      def initialize(key: required('key'), secret: required('secret'))
+      def initialize(key: required('key'), secret: required('secret'), token: nil)
         @key = key
         @secret = secret
+        @token = token
       end
 
       # Send a request to Airship's API
@@ -25,10 +27,11 @@ module Urbanairship
       # @param [Object] body Request Body
       # @param [Object] url Request URL
       # @param [Object] content_type Content-Type
-      # @param [Object] version API Version
+      # @param [Object] encoding Encoding
+      # @param [Symbol] auth_type (:basic|:bearer)
       # @return [Object] Push Response
       def send_request(method: required('method'), url: required('url'), body: nil,
-                       content_type: nil, encoding: nil)
+                       content_type: nil, encoding: nil, auth_type: :basic)
         req_type = case method
           when 'GET'
             :get
@@ -46,9 +49,14 @@ module Urbanairship
         headers['Accept'] = 'application/vnd.urbanairship+json; version=3'
         headers['Content-type'] = content_type unless content_type.nil?
         headers['Content-Encoding'] = encoding unless encoding.nil?
+        if auth_type == :bearer
+          raise ArgumentError.new('token must be provided as argument if auth_type=bearer') if @token.nil?
 
-        debug = "Making #{method} request to #{url}.\n"+
-            "\tHeaders:\n"
+          headers['X-UA-Appkey'] = @key
+          headers['Authorization'] = "Bearer #{@token}"
+        end
+
+        debug = "Making #{method} request to #{url}.\n"+ "\tHeaders:\n"
         debug += "\t\tcontent-type: #{content_type}\n" unless content_type.nil?
         debug += "\t\tcontent-encoding: gzip\n" unless encoding.nil?
         debug += "\t\taccept: application/vnd.urbanairship+json; version=3\n"
@@ -56,15 +64,20 @@ module Urbanairship
 
         logger.debug(debug)
 
-        response = RestClient::Request.execute(
+        params = {
           method: method,
           url: url,
           headers: headers,
-          user: @key,
-          password: @secret,
           payload: body,
           timeout: Urbanairship.configuration.timeout
-        )
+        }
+
+        if auth_type == :basic
+          params[:user] = @key
+          params[:password] = @secret
+        end
+
+        response = RestClient::Request.execute(params)
 
         logger.debug("Received #{response.code} response. Headers:\n\t#{response.headers}\nBody:\n\t#{response.body}")
         Response.check_code(response.code, response)

--- a/spec/lib/urbanairship/client_spec.rb
+++ b/spec/lib/urbanairship/client_spec.rb
@@ -1,12 +1,36 @@
 require 'spec_helper'
 require 'urbanairship/client'
 
-
 describe Urbanairship::Client do
   UA = Urbanairship
 
   it 'is instantiated with a "key" and "secret"' do
     ua_client = UA::Client.new(key: '123', secret: 'abc')
     expect(ua_client).not_to be_nil
+  end
+
+  it 'uses basic auth' do
+    mock_response = double('response')
+    allow(mock_response).to(receive_messages(code: 200, headers: '', body: '{}'))
+    expect(RestClient::Request).to(receive(:execute).with(hash_including({ user: '123', password: 'abc' })))
+                               .and_return(mock_response)
+
+    ua_client = UA::Client.new(key: '123', secret: 'abc')
+    ua_client.send_request(method: 'POST', url: UA::Common::CHANNEL_URL)
+  end
+
+  it 'uses bearer auth' do
+    mock_response = double('response')
+    allow(mock_response).to(receive_messages(code: 200, headers: '', body: '{}'))
+
+    expected_headers = {
+      'X-UA-Appkey' => '123',
+      'Authorization' => 'Bearer test-token'
+    }
+    expect(RestClient::Request).to(receive(:execute).with(include(headers: include(expected_headers))))
+                               .and_return(mock_response)
+
+    ua_client = UA::Client.new(key: '123', secret: 'abc', token: 'test-token')
+    ua_client.send_request(method: 'POST', url: UA::Common::CHANNEL_URL, auth_type: :bearer)
   end
 end


### PR DESCRIPTION
**If you want your PR addressed quickly, please also reach out to our [support team](https://support.airship.com/)
so we can understand when you need it reviewed and how it is impacting your use of our services.** We also generally
will not release new versions of our library without new feature support, a bug fix, or a clear reason from a customer
why an update is required to minimize how often other customers need to update.

### What does this do and why?
This adds parameters to the `UA::Client` constructor & `UA::Client.send_request` method to specify auth token parameters. The custom events endpoint requires Bearer Authentication, while every other endpoint requires Basic.

https://docs.airship.com/api/ua/index.html#operation/api/custom-events/post

### Additional notes for reviewers
* I had to remove the guard-rspec dependency in order to install the bundle under ruby 2.2.5
* I've opened a related support request: Ticket #66610

### Testing
- [x] If these changes added new functionality, I tested them against the live API with real auth
- [x] I wrote tests covering these changes

* I've tested for Ruby versions:

- [x] 2.2.5 - I had to remove the `guard-rspec` dependency in order to install the bundle under ruby 2.2.5
- [x] 2.3.1
- [x] 2.5.7

### Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed Airship's contribution agreement form.

### Screenshots
* If applicable
