### PR TITLE
Change targeted Airship server on a request basis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,27 @@ Simple Tag Push
     >>> p.send_push
 
 
+Specify the Airship server used to make your requests
+-----------------------------------------------------
+    >>> require 'urbanairship'
+    >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret')
+    >>> # By default, the request will be sent to the 'go.airship.us' server
+
+    >>> require 'urbanairship'
+    >>> Urbanairship.configure do |config|
+    >>>   config.server = 'go.airship.eu'
+    >>> end
+    >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret')
+    >>> # The request will be sent to the 'go.airship.eu' server
+
+    >>> require 'urbanairship'
+    >>> Urbanairship.configure do |config|
+    >>>   config.server = 'go.airship.eu'
+    >>> end
+    >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret', server: 'go.airship.us')
+    >>> # The Urbanairship configuration is overidden by the client and the
+    >>> # request will be sent to the 'go.airship.us' server
+
 Contributing
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -123,23 +123,28 @@ Simple Tag Push
 
 Specify the Airship server used to make your requests
 -----------------------------------------------------
+By default, the request will be sent to the 'go.airship.us' server:
+
     >>> require 'urbanairship'
     >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret')
-    >>> # By default, the request will be sent to the 'go.airship.us' server
+
+You can change the server globally in the Urbanairship configuration:
 
     >>> require 'urbanairship'
     >>> Urbanairship.configure do |config|
     >>>   config.server = 'go.airship.eu'
     >>> end
     >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret')
-    >>> # The request will be sent to the 'go.airship.eu' server
+    >>> # request will be sent to the 'go.airship.eu' server
+
+Finally, you can change the targeted server on a request basis:
 
     >>> require 'urbanairship'
     >>> Urbanairship.configure do |config|
     >>>   config.server = 'go.airship.eu'
     >>> end
     >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret', server: 'go.airship.us')
-    >>> # The Urbanairship configuration is overidden by the client and the
+    >>> # The Urbanairship configuration is overridden by the client and the
     >>> # request will be sent to the 'go.airship.us' server
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -38,17 +38,23 @@ Installation
 
 If you have the ``bundler`` gem (if not you can get it with
 ``$ gem install bundler``) add this line to your application's
-Gemfile::
+Gemfile:
 
-    >>> gem 'urbanairship'
+.. code-block::
 
-And then execute::
+   >>> $ gem 'urbanairship'
 
-    >>> $ bundle
+And then execute:
 
-OR install it yourself as::
+.. code-block::
 
-    >>> gem install urbanairship
+   >>> $ bundle
+
+OR install it yourself as:
+
+.. code-block::
+
+   >>> $ gem install urbanairship
 
 
 Configuration
@@ -56,22 +62,28 @@ Configuration
 
 In your app initialization, you can do something like the following:
 
-    >>> require 'urbanairship'
-    >>> Urbanairship.configure do |config|
-    >>>   config.server = 'go.airship.eu'
-    >>>   config.log_path = '/path/to/your/logfile'
-    >>>   config.log_level = Logger::WARN
-    >>>   config.timeout = 60
-    >>> end
+.. code-block:: ruby
+
+   require 'urbanairship'
+
+   Urbanairship.configure do |config|
+     config.server = 'go.airship.eu'
+     config.log_path = '/path/to/your/logfile'
+     config.log_level = Logger::WARN
+     config.timeout = 60
+   end
+
 
 If you want to use a custom logger (e.g Rails.logger), you can do:
 
-    >>> require 'urbanairship'
-    >>> Urbanairship.configure do |config|
-    >>>   config.custom_logger = Rails.logger
-    >>>   config.log_level = Logger::WARN
-    >>>   config.timeout = 60
-    >>> end
+.. code-block:: ruby
+
+   require 'urbanairship'
+
+   Urbanairship.configure do |config|
+     config.custom_logger = Rails.logger
+     config.log_level = Logger::WARN
+   end
 
 Available Configurations
 ------------------------
@@ -98,54 +110,71 @@ information.
 Broadcast to All Devices
 ------------------------
 
-    >>> require 'urbanairship'
-    >>> UA = Urbanairship
-    >>> airship = UA::Client.new(key:'application_key', secret:'master_secret')
-    >>> p = airship.create_push
-    >>> p.audience = UA.all
-    >>> p.notification = UA.notification(alert: 'Hello')
-    >>> p.device_types = UA.all
-    >>> p.send_push
+.. code-block:: ruby
 
+   require 'urbanairship'
+
+   UA = Urbanairship
+
+   airship = UA::Client.new(key:'application_key', secret:'master_secret')
+   p = airship.create_push
+   p.audience = UA.all
+   p.notification = UA.notification(alert: 'Hello')
+   p.device_types = UA.all
+   p.send_push
 
 Simple Tag Push
 ---------------
 
-    >>> require 'urbanairship'
-    >>> UA = Urbanairship
-    >>> airship = UA::Client.new(key:'application_key', secret:'master_secret')
-    >>> p = airship.create_push
-    >>> p.audience = UA.tag('some_tag')
-    >>> p.notification = UA.notification(alert: 'Hello')
-    >>> p.device_types = UA.all
-    >>> p.send_push
+.. code-block:: ruby
 
+   require 'urbanairship'
+
+   UA = Urbanairship
+
+   airship = UA::Client.new(key:'application_key', secret:'master_secret')
+   p = airship.create_push
+   p.audience = UA.tag('some_tag')
+   p.notification = UA.notification(alert: 'Hello')
+   p.device_types = UA.all
+   p.send_push
 
 Specify the Airship server used to make your requests
 -----------------------------------------------------
 By default, the request will be sent to the 'go.airship.us' server:
 
-    >>> require 'urbanairship'
-    >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret')
+.. code-block:: ruby
+
+   require 'urbanairship'
+
+   Urbanairship::Client.new(key:'application_key', secret:'master_secret')
 
 You can change the server globally in the Urbanairship configuration:
 
-    >>> require 'urbanairship'
-    >>> Urbanairship.configure do |config|
-    >>>   config.server = 'go.airship.eu'
-    >>> end
-    >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret')
-    >>> # request will be sent to the 'go.airship.eu' server
+.. code-block:: ruby
+
+   require 'urbanairship'
+
+   Urbanairship.configure do |config|
+     config.server = 'go.airship.eu'
+   end
+
+   Urbanairship::Client.new(key:'application_key', secret:'master_secret')
+   # request will be sent to the 'go.airship.eu' server
 
 Finally, you can change the targeted server on a request basis:
 
-    >>> require 'urbanairship'
-    >>> Urbanairship.configure do |config|
-    >>>   config.server = 'go.airship.eu'
-    >>> end
-    >>> Urbanairship::Client.new(key:'application_key', secret:'master_secret', server: 'go.airship.us')
-    >>> # The Urbanairship configuration is overridden by the client and the
-    >>> # request will be sent to the 'go.airship.us' server
+.. code-block:: ruby
+
+   require 'urbanairship'
+
+   Urbanairship.configure do |config|
+     config.server = 'go.airship.eu'
+   end
+
+   Urbanairship::Client.new(key:'application_key', secret:'master_secret', server: 'go.airship.us')
+   # The Urbanairship configuration is overridden by the client and the
+   # request will be sent to the 'go.airship.us' server
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,7 @@ Available Configurations
 
 - **log_path**: Allows to define the folder where the log file will be created (the default is nil).
 - **log_level**: Allows to define the log level and only messages at that level or higher will be printed (the default is INFO).
+- **server**: Allow to define the Airship server you want to use ("go.airship.eu" or "go.urbanairship.com")
 - **timeout**: Allows to define the request timeout in seconds (the default is 5).
 
 

--- a/lib/urbanairship/ab_tests/ab_test.rb
+++ b/lib/urbanairship/ab_tests/ab_test.rb
@@ -19,7 +19,7 @@ module Urbanairship
             def list_ab_test
                 response = @client.send_request(
                     method: 'GET',
-                    url: experiments_url(format_url_with_params)
+                    path: experiments_path(format_url_with_params)
                 )
                 logger.info("Looking up A/B Tests for project")
                 response
@@ -29,7 +29,7 @@ module Urbanairship
                 response = @client.send_request(
                     method: 'POST',
                     body: JSON.dump(experiment_object),
-                    url: experiments_url,
+                    path: experiments_path,
                     content_type: 'application/json'
                 )
                 logger.info("Created A/B Test")
@@ -39,7 +39,7 @@ module Urbanairship
             def list_scheduled_ab_test
                 response = @client.send_request(
                     method: 'GET',
-                    url: experiments_url('scheduled' + format_url_with_params)
+                    path: experiments_path('scheduled' + format_url_with_params)
                 )
                 logger.info("Looking up scheduled A/B Tests for project")
                 response
@@ -49,7 +49,7 @@ module Urbanairship
                 fail ArgumentError, 'experiment_id must be set to delete individual A/B test' if @experiment_id.nil?
                 response = @client.send_request(
                     method: 'DELETE',
-                    url: experiments_url('scheduled/' + experiment_id)
+                    path: experiments_path('scheduled/' + experiment_id)
                 )
                 logger.info("Deleting A/B test with ID #{experiment_id}")
                 response
@@ -59,7 +59,7 @@ module Urbanairship
                 response = @client.send_request(
                     method: 'POST',
                     body: JSON.dump(experiment_object),
-                    url: experiments_url('validate'),
+                    path: experiments_path('validate'),
                     content_type: 'application/json'
                 )
                 logger.info("Validating A/B Test")
@@ -70,7 +70,7 @@ module Urbanairship
                 fail ArgumentError, 'experiment_id must be set to lookup individual A/B Test' if @experiment_id.nil?
                 response = @client.send_request(
                     method: 'GET',
-                    url: experiments_url(experiment_id)
+                    path: experiments_path(experiment_id)
                 )
                 logger.info("Looking up A/B test with ID #{experiment_id}")
                 response

--- a/lib/urbanairship/automations/automation.rb
+++ b/lib/urbanairship/automations/automation.rb
@@ -22,7 +22,7 @@ module Urbanairship
                 response = @client.send_request(
                     method: 'POST',
                     body: JSON.dump(pipeline_object),
-                    url: pipelines_url,
+                    path: pipelines_path,
                     content_type: 'application/json'
                 )
                 logger.info("Created Automation")
@@ -32,7 +32,7 @@ module Urbanairship
             def list_automations
                 response = @client.send_request(
                     method: 'GET',
-                    url: pipelines_url(format_url_with_params)
+                    path: pipelines_path(format_url_with_params)
                 )
                 logger.info("Looking up automations for project")
                 response
@@ -41,7 +41,7 @@ module Urbanairship
             def list_deleted_automations
                 response = @client.send_request(
                     method: 'GET',
-                    url: pipelines_url('deleted' + format_url_with_params)
+                    path: pipelines_path('deleted' + format_url_with_params)
                 )
                 logger.info("Looking up deleted automations for project")
                 response
@@ -51,7 +51,7 @@ module Urbanairship
                 response = @client.send_request(
                     method: 'POST',
                     body: JSON.dump(pipeline_object),
-                    url: pipelines_url('validate'),
+                    path: pipelines_path('validate'),
                     content_type: 'application/json'
                 )
                 logger.info("Validating Automation")
@@ -62,7 +62,7 @@ module Urbanairship
                 fail ArgumentError, 'pipeline_id must be set to lookup individual automation' if @pipeline_id.nil?
                 response = @client.send_request(
                     method: 'GET',
-                    url: pipelines_url(pipeline_id)
+                    path: pipelines_path(pipeline_id)
                 )
                 logger.info("Looking up automation with id #{pipeline_id}")
                 response
@@ -74,7 +74,7 @@ module Urbanairship
                 response = @client.send_request(
                     method: 'PUT',
                     body: JSON.dump(pipeline_object),
-                    url: pipelines_url(pipeline_id),
+                    path: pipelines_path(pipeline_id),
                     content_type: 'application/json'
                 )
                 logger.info("Validating Automation")
@@ -85,7 +85,7 @@ module Urbanairship
                 fail ArgumentError, 'pipeline_id must be set to delete individual automation' if @pipeline_id.nil?
                 response = @client.send_request(
                     method: 'DELETE',
-                    url: pipelines_url(pipeline_id)
+                    path: pipelines_path(pipeline_id)
                 )
                 logger.info("Deleting automation with id #{pipeline_id}")
                 response

--- a/lib/urbanairship/client.rb
+++ b/lib/urbanairship/client.rb
@@ -29,14 +29,14 @@ module Urbanairship
       #
       # @param [Object] method HTTP Method
       # @param [Object] body Request Body
+      # @param [Object] path Request path
       # @param [Object] url Request URL
       # @param [Object] content_type Content-Type
       # @param [Object] encoding Encoding
       # @param [Symbol] auth_type (:basic|:bearer)
-      # @param [Object] path Request path
       # @return [Object] Push Response
-      def send_request(method: required('method'), url: nil, body: nil,
-                       content_type: nil, encoding: nil, auth_type: :basic, path: nil)
+      def send_request(method: required('method'), path: nil, url: nil, body: nil,
+                       content_type: nil, encoding: nil, auth_type: :basic)
         req_type = case method
           when 'GET'
             :get
@@ -49,6 +49,8 @@ module Urbanairship
           else
             fail 'Method was not "GET" "POST" "PUT" or "DELETE"'
         end
+
+        raise ArgumentError.new("path and url can't be both nil") if path.nil? && url.nil?
 
         headers = {'User-agent' => 'UARubyLib/' + Urbanairship::VERSION}
         headers['Accept'] = 'application/vnd.urbanairship+json; version=3'

--- a/lib/urbanairship/client.rb
+++ b/lib/urbanairship/client.rb
@@ -29,9 +29,10 @@ module Urbanairship
       # @param [Object] content_type Content-Type
       # @param [Object] encoding Encoding
       # @param [Symbol] auth_type (:basic|:bearer)
+      # @param [Object] path Request path
       # @return [Object] Push Response
-      def send_request(method: required('method'), url: required('url'), body: nil,
-                       content_type: nil, encoding: nil, auth_type: :basic)
+      def send_request(method: required('method'), url: nil, body: nil,
+                       content_type: nil, encoding: nil, auth_type: :basic, path: nil)
         req_type = case method
           when 'GET'
             :get
@@ -49,12 +50,14 @@ module Urbanairship
         headers['Accept'] = 'application/vnd.urbanairship+json; version=3'
         headers['Content-type'] = content_type unless content_type.nil?
         headers['Content-Encoding'] = encoding unless encoding.nil?
-        
+
         if auth_type == :bearer
           raise ArgumentError.new('token must be provided as argument if auth_type=bearer') if @token.nil?
           headers['X-UA-Appkey'] = @key
           headers['Authorization'] = "Bearer #{@token}"
         end
+
+        url = "https://#{Urbanairship.configuration.server}/api#{path}" unless path.nil?
 
         debug = "Making #{method} request to #{url}.\n"+ "\tHeaders:\n"
         debug += "\t\tcontent-type: #{content_type}\n" unless content_type.nil?

--- a/lib/urbanairship/client.rb
+++ b/lib/urbanairship/client.rb
@@ -13,11 +13,15 @@ module Urbanairship
       #
       # @param [Object] key Application Key
       # @param [Object] secret Application Secret
+      # @param [String] server Airship server to use ("go.airship.eu" or "go.urbanairship.com").
+      #                        Used only when the request is sent with a "path", not an "url".
       # @param [String] token Application Auth Token (for custom events endpoint)
       # @return [Object] Client
-      def initialize(key: required('key'), secret: required('secret'), token: nil)
+      def initialize(key: required('key'), secret: required('secret'),
+                     server: Urbanairship.configuration.server, token: nil)
         @key = key
         @secret = secret
+        @server = server
         @token = token
       end
 
@@ -57,7 +61,7 @@ module Urbanairship
           headers['Authorization'] = "Bearer #{@token}"
         end
 
-        url = "https://#{Urbanairship.configuration.server}/api#{path}" unless path.nil?
+        url = "https://#{@server}/api#{path}" unless path.nil?
 
         debug = "Making #{method} request to #{url}.\n"+ "\tHeaders:\n"
         debug += "\t\tcontent-type: #{content_type}\n" unless content_type.nil?

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -32,8 +32,8 @@ module Urbanairship
       "/experiments/#{path}"
     end
 
-    def lists_url(path='')
-      url_for("/lists/#{path}")
+    def lists_path(path='')
+      "/lists/#{path}"
     end
 
     def location_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -12,6 +12,10 @@ module Urbanairship
       "/apids/#{path}"
     end
 
+    def channel_path(path='')
+      "/channels/#{path}"
+    end
+
     def channel_url(path='')
       url_for("/channels/#{path}")
     end
@@ -38,6 +42,10 @@ module Urbanairship
 
     def location_url(path='')
       url_for("/location/#{path}")
+    end
+
+    def named_users_path(path='')
+      "/named_users/#{path}"
     end
 
     def named_users_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -64,8 +64,8 @@ module Urbanairship
       "/schedules/#{path}"
     end
 
-    def segments_url(path='')
-      url_for("/segments/#{path}")
+    def segments_path(path='')
+      "/segments/#{path}"
     end
 
     # Helper method for required keyword args in Ruby 2.0 that is compatible with 2.1+

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -8,8 +8,8 @@ module Urbanairship
       "https://#{Urbanairship.configuration.server}/api#{path}"
     end
 
-    def apid_url(path='')
-      url_for("/apids/#{path}")
+    def apid_path(path='')
+      "/apids/#{path}"
     end
 
     def channel_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -60,8 +60,8 @@ module Urbanairship
       "/reports/#{path}"
     end
 
-    def schedules_url(path='')
-      url_for("/schedules/#{path}")
+    def schedules_path(path='')
+      "/schedules/#{path}"
     end
 
     def segments_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -20,8 +20,8 @@ module Urbanairship
       "/create-and-send/#{path}"
     end
 
-    def custom_events_url(path='')
-      url_for("/custom-events/#{path}")
+    def custom_events_path(path='')
+      "/custom-events/#{path}"
     end
 
     def device_token_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -16,8 +16,8 @@ module Urbanairship
       "/channels/#{path}"
     end
 
-    def create_and_send_url(path='')
-      url_for("/create-and-send/#{path}")
+    def create_and_send_path(path='')
+      "/create-and-send/#{path}"
     end
 
     def custom_events_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -28,8 +28,8 @@ module Urbanairship
       "/device_tokens/#{path}"
     end
 
-    def experiments_url(path='')
-      url_for("/experiments/#{path}")
+    def experiments_path(path='')
+      "/experiments/#{path}"
     end
 
     def lists_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -36,8 +36,8 @@ module Urbanairship
       "/lists/#{path}"
     end
 
-    def location_url(path='')
-      url_for("/location/#{path}")
+    def location_path(path='')
+      "/location/#{path}"
     end
 
     def named_users_path(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -24,8 +24,8 @@ module Urbanairship
       "/custom-events/#{path}"
     end
 
-    def device_token_url(path='')
-      url_for("/device_tokens/#{path}")
+    def device_token_path(path='')
+      "/device_tokens/#{path}"
     end
 
     def experiments_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -4,10 +4,6 @@ require 'urbanairship/loggable'
 module Urbanairship
   # Features mixed in to all classes
   module Common
-    def url_for(path)
-      "https://#{Urbanairship.configuration.server}/api#{path}"
-    end
-
     def apid_path(path='')
       "/apids/#{path}"
     end

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -157,15 +157,15 @@ module Urbanairship
 
       def initialize(client: required('client'))
         @client = client
-        @next_page_url = nil
-        @next_page_path = nil
-        @data_list = nil
-        @data_attribute = nil
         @count = 0
+        @data_attribute = nil
+        @data_list = nil
+        @next_page_path = nil
+        @next_page_url = nil
       end
 
       def each
-        while @next_page_url || @next_page_path
+        while @next_page_path || @next_page_url
           load_page
 
           @data_list.each do |value|
@@ -185,8 +185,8 @@ module Urbanairship
         logger.info("Retrieving data from: #{@next_page_url || @next_page_path}")
         params = {
             method: 'GET',
-            url: @next_page_url,
-            path: @next_page_path
+            path: @next_page_path,
+            url: @next_page_url
           }.select { |k, v| !v.nil? }
         response = @client.send_request(params)
 

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -48,8 +48,8 @@ module Urbanairship
       "/open/#{path}"
     end
 
-    def pipelines_url(path='')
-      url_for("/pipelines/#{path}")
+    def pipelines_path(path='')
+      "/pipelines/#{path}"
     end
 
     def push_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -157,7 +157,7 @@ module Urbanairship
 
       def initialize(client: required('client'))
         @client = client
-        @next_page = nil
+        @next_page_url = nil
         @next_page_path = nil
         @data_list = nil
         @data_attribute = nil
@@ -165,7 +165,7 @@ module Urbanairship
       end
 
       def each
-        while @next_page || @next_page_path
+        while @next_page_url || @next_page_path
           load_page
 
           @data_list.each do |value|
@@ -182,41 +182,41 @@ module Urbanairship
       private
 
       def load_page
-        logger.info("Retrieving data from: #{@next_page}")
+        logger.info("Retrieving data from: #{@next_page_url || @next_page_path}")
         params = {
             method: 'GET',
-            url: @next_page,
+            url: @next_page_url,
             path: @next_page_path
           }.select { |k, v| !v.nil? }
         response = @client.send_request(params)
 
         @data_list = get_new_data(response)
-        @next_page = get_next_page(response)
+        @next_page_url = get_next_page_url(response)
         @next_page_path = nil
       end
 
-      def extract_next_page(response)
+      def extract_next_page_url(response)
         response['body']['next_page']
       end
 
       def get_new_data(response)
-        potential_next_page = extract_next_page(response)
+        potential_next_page_url = extract_next_page_url(response)
 
-        # if potential_next_page is the same as the current page, we have
+        # if potential_next_page_url is the same as the current page, we have
         # repeats in the response and we don't want to load them
-        return [] if potential_next_page && get_next_page(response).nil?
+        return [] if potential_next_page_url && get_next_page_url(response).nil?
 
         response['body'][@data_attribute]
       end
 
-      def get_next_page(response)
-        potential_next_page = extract_next_page(response)
-        return nil if potential_next_page.nil?
+      def get_next_page_url(response)
+        potential_next_page_url = extract_next_page_url(response)
+        return nil if potential_next_page_url.nil?
 
-        # if potential_next_page is the same as the current page, we have
+        # if potential_next_page_url is the same as the current page, we have
         # repeats in the response and we don't want to check the next pages
-        return potential_next_page if @next_page && potential_next_page != @next_page
-        return potential_next_page if @next_page_path && !potential_next_page.end_with?(@next_page_path)
+        return potential_next_page_url if @next_page_url && potential_next_page_url != @next_page_url
+        return potential_next_page_url if @next_page_path && !potential_next_page_url.end_with?(@next_page_path)
         nil
       end
     end

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -44,10 +44,6 @@ module Urbanairship
       "/named_users/#{path}"
     end
 
-    def named_users_url(path='')
-      url_for("/named_users/#{path}")
-    end
-
     def open_channel_path(path='')
       "/open/#{path}"
     end

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -168,6 +168,23 @@ module Urbanairship
         @count = 0
       end
 
+      def each
+        while @next_page || @next_page_path
+          load_page
+
+          @data_list.each do |value|
+            @count += 1
+            yield value
+          end
+        end
+      end
+
+      def count
+        @count
+      end
+
+      private
+
       def load_page
         logger.info("Retrieving data from: #{@next_page}")
         params = {
@@ -205,21 +222,6 @@ module Urbanairship
         return potential_next_page if @next_page && potential_next_page != @next_page
         return potential_next_page if @next_page_path && !potential_next_page.end_with?(@next_page_path)
         nil
-      end
-
-      def each
-        while @next_page || @next_page_path
-          load_page
-
-          @data_list.each do |value|
-            @count += 1
-            yield value
-          end
-        end
-      end
-
-      def count
-        @count
       end
     end
   end

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -52,8 +52,8 @@ module Urbanairship
       "/pipelines/#{path}"
     end
 
-    def push_url(path='')
-      url_for("/push/#{path}")
+    def push_path(path='')
+      "/push/#{path}"
     end
 
     def reports_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -16,10 +16,6 @@ module Urbanairship
       "/channels/#{path}"
     end
 
-    def channel_url(path='')
-      url_for("/channels/#{path}")
-    end
-
     def create_and_send_url(path='')
       url_for("/create-and-send/#{path}")
     end
@@ -52,8 +48,8 @@ module Urbanairship
       url_for("/named_users/#{path}")
     end
 
-    def open_channel_url(path='')
-      channel_url("/open/#{path}")
+    def open_channel_path(path='')
+      "/open/#{path}"
     end
 
     def pipelines_url(path='')

--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -56,8 +56,8 @@ module Urbanairship
       "/push/#{path}"
     end
 
-    def reports_url(path='')
-      url_for("/reports/#{path}")
+    def reports_path(path='')
+      "/reports/#{path}"
     end
 
     def schedules_url(path='')

--- a/lib/urbanairship/custom_events/custom_event.rb
+++ b/lib/urbanairship/custom_events/custom_event.rb
@@ -23,7 +23,7 @@ module Urbanairship
           body: JSON.dump(events),
           content_type: 'application/json',
           method: 'POST',
-          url: custom_events_url
+          path: custom_events_path
         )
         cer = CustomEventResponse.new(body: response['body'], code: response['code'])
         logger.info { cer.format }

--- a/lib/urbanairship/devices/channel_tags.rb
+++ b/lib/urbanairship/devices/channel_tags.rb
@@ -15,7 +15,7 @@ module Urbanairship
         @add_group = {}
         @remove_group = {}
         @set_group = {}
-        @url = channel_url('tags/')
+        @path = channel_path('tags/')
       end
 
       def set_audience(ios: nil, android: nil, amazon: nil)
@@ -62,7 +62,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: @url,
+          path: @path,
           content_type: 'application/json'
         )
         logger.info("Set tags for audience: #{@audience}")

--- a/lib/urbanairship/devices/channel_uninstall.rb
+++ b/lib/urbanairship/devices/channel_uninstall.rb
@@ -53,7 +53,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(body),
-          url: open_channel_url('uninstall/'),
+          path: open_channel_path('uninstall/'),
           content_type: 'application/json'
         )
 

--- a/lib/urbanairship/devices/channel_uninstall.rb
+++ b/lib/urbanairship/devices/channel_uninstall.rb
@@ -23,7 +23,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(channels),
-          url: channel_url('uninstall/'),
+          path: channel_path('uninstall/'),
           content_type: 'application/json'
         )
 

--- a/lib/urbanairship/devices/create_and_send.rb
+++ b/lib/urbanairship/devices/create_and_send.rb
@@ -84,7 +84,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(scheduled_payload),
-          url: schedules_url('create-and-send'),
+          path: schedules_path('create-and-send'),
           content_type: 'application/json'
         )
         logger.info("Scheduling create and send operation with name #{@name}")

--- a/lib/urbanairship/devices/create_and_send.rb
+++ b/lib/urbanairship/devices/create_and_send.rb
@@ -52,7 +52,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: create_and_send_url,
+          path: create_and_send_path,
           content_type: 'application/json'
         )
         logger.info("Running create and send for addresses #{@addresses}")
@@ -63,7 +63,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: create_and_send_url('validate'),
+          path: create_and_send_path('validate'),
           content_type: 'application/json'
         )
         logger.info("Validating payload for create and send")

--- a/lib/urbanairship/devices/devicelist.rb
+++ b/lib/urbanairship/devices/devicelist.rb
@@ -17,7 +17,7 @@ module Urbanairship
       def lookup(uuid: required('uuid'))
         response = @client.send_request(
           method: 'GET',
-          url: channel_url(uuid)
+          path: channel_path(uuid)
         )
         logger.info("Retrieved channel information for #{uuid}")
         response['body']['channel']
@@ -36,7 +36,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: channel_url('attributes'),
+          path: channel_path('attributes'),
           content_type: 'application/json'
         )
         response
@@ -46,7 +46,7 @@ module Urbanairship
     class ChannelList < Urbanairship::Common::PageIterator
       def initialize(client: required('client'))
         super(client: client)
-        @next_page = channel_url
+        @next_page_path = channel_path
         @data_attribute = 'channels'
       end
     end

--- a/lib/urbanairship/devices/devicelist.rb
+++ b/lib/urbanairship/devices/devicelist.rb
@@ -64,7 +64,7 @@ module Urbanairship
 
         resp = @client.send_request(
           method: 'GET',
-          url: device_token_url(token)
+          path: device_token_path(token)
         )
         logger.info("Looking up info on device token #{token}")
         resp
@@ -77,7 +77,7 @@ module Urbanairship
 
       def initialize(client: required('client'))
         super(client: client)
-        @next_page = device_token_url
+        @next_page_path = device_token_path
         @data_attribute = 'device_tokens'
       end
     end

--- a/lib/urbanairship/devices/devicelist.rb
+++ b/lib/urbanairship/devices/devicelist.rb
@@ -95,7 +95,7 @@ module Urbanairship
 
         resp = @client.send_request(
           method: 'GET',
-          url: apid_url(apid)
+          path: apid_path(apid)
         )
         logger.info("Retrieved info on apid #{apid}")
         resp
@@ -105,7 +105,7 @@ module Urbanairship
     class APIDList < Urbanairship::Common::PageIterator
       def initialize(client: required('client'))
         super(client: client)
-        @next_page = apid_url
+        @next_page_path = apid_path
         @data_attribute = 'apids'
       end
     end

--- a/lib/urbanairship/devices/email.rb
+++ b/lib/urbanairship/devices/email.rb
@@ -41,7 +41,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: channel_url('email'),
+          path: channel_path('email'),
           content_type: 'application/json'
         )
         logger.info("Registering email channel with address #{address}")
@@ -58,7 +58,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: channel_url('email/uninstall'),
+          path: channel_path('email/uninstall'),
           content_type: 'application/json'
         )
         logger.info("Uninstalling email channel with address #{address}")
@@ -70,7 +70,7 @@ module Urbanairship
 
         response = @client.send_request(
           method: 'GET',
-          url: channel_url('email/' + address)
+          path: channel_path('email/' + address)
         )
         logger.info("Looking up email channel with address #{address}")
         response
@@ -95,7 +95,7 @@ module Urbanairship
 
         response = @client.send_request(
           method: 'PUT',
-          url: channel_url('email/' + channel_id),
+          path: channel_path('email/' + channel_id),
           body: JSON.dump(payload),
           content_type: 'application/json'
         )
@@ -109,7 +109,7 @@ module Urbanairship
 
       def initialize(client: required('client'))
         super(client: client)
-        @url = channel_url('email/tags')
+        @path = channel_path('email/tags')
       end
 
       def set_audience(email_address: required('email_address'))

--- a/lib/urbanairship/devices/named_user.rb
+++ b/lib/urbanairship/devices/named_user.rb
@@ -65,7 +65,7 @@ module Urbanairship
 
       def initialize(client: required('client'))
         super(client: client)
-        @url = named_users_url('tags/')
+        @path = named_users_path('tags/')
       end
 
       def set_audience(user_ids: required('user_ids'))

--- a/lib/urbanairship/devices/named_user.rb
+++ b/lib/urbanairship/devices/named_user.rb
@@ -25,7 +25,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: named_users_url('/associate'),
+          path: named_users_path('/associate'),
           content_type: 'application/json'
         )
         logger.info { "Associated channel_id #{channel_id} with named_user #{@named_user_id}" }
@@ -40,7 +40,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: named_users_url('/disassociate'),
+          path: named_users_path('/disassociate'),
           content_type: 'application/json'
         )
         logger.info { "Dissociated channel_id #{channel_id}" }
@@ -52,7 +52,7 @@ module Urbanairship
            'named_user_id is required for lookup' if @named_user_id.nil?
         response = @client.send_request(
             method: 'GET',
-            url: named_users_url('?id=' + @named_user_id),
+            path: named_users_path('?id=' + @named_user_id),
         )
         logger.info { "Retrieved information on named_user_id #{@named_user_id}" }
         response
@@ -79,7 +79,7 @@ module Urbanairship
 
       def initialize(client: required('client'))
         super(client: client)
-        @next_page = named_users_url
+        @next_page_path = named_users_path
         @data_attribute = 'named_users'
       end
     end
@@ -101,7 +101,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: named_users_url('/uninstall'),
+          path: named_users_path('/uninstall'),
           content_type: 'application/json'
         )
         logger.info { "Uninstalled named_user_ids #{@named_user_ids} " }

--- a/lib/urbanairship/devices/open_channel.rb
+++ b/lib/urbanairship/devices/open_channel.rb
@@ -90,7 +90,7 @@ module Urbanairship
 
         response = @client.send_request(
           method: 'GET',
-          url: channel_url(channel_id)
+          path: channel_path(channel_id)
         )
         logger.info("Looking up info on device token #{channel_id}")
         response

--- a/lib/urbanairship/devices/open_channel.rb
+++ b/lib/urbanairship/devices/open_channel.rb
@@ -45,7 +45,7 @@ module Urbanairship
 
         response = @client.send_request(
           method: 'POST',
-          url: open_channel_url,
+          path: open_channel_path,
           body: JSON.dump(body),
           content_type: 'application/json'
         )
@@ -77,7 +77,7 @@ module Urbanairship
 
         response = @client.send_request(
           method: 'POST',
-          url: open_channel_url,
+          path: open_channel_path,
           body: JSON.dump(body),
           content_type: 'application/json'
         )

--- a/lib/urbanairship/devices/segment.rb
+++ b/lib/urbanairship/devices/segment.rb
@@ -28,7 +28,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: segments_url,
+          path: segments_path,
           content_type: 'application/json'
         )
         logger.info { "Successful segment creation: #{@display_name}" }
@@ -45,7 +45,7 @@ module Urbanairship
           'id must be set to a valid string' if id.nil?
         response = @client.send_request(
           method: 'GET',
-          url: segments_url(id)
+          path: segments_path(id)
         )
         logger.info("Retrieved segment information for #{id}")
         @id = id
@@ -69,7 +69,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'PUT',
           body: JSON.dump(data),
-          url: segments_url(@id),
+          path: segments_path(@id),
           content_type: 'application/json'
         )
         logger.info { "Successful segment update: #{@display_name}" }
@@ -80,13 +80,11 @@ module Urbanairship
       #
       # @ returns [Object] response HTTP response
       def delete
-        fail ArgumentError,
-          'id cannot be nil' if id.nil?
+        fail ArgumentError, 'id cannot be nil' if id.nil?
 
-        url = segments_url(id)
         response = @client.send_request(
           method: 'DELETE',
-          url: url
+          path: segments_path(id)
         )
         logger.info { "Successful segment deletion: #{@display_name}" }
         response
@@ -98,7 +96,7 @@ module Urbanairship
 
       def initialize(client: required('client'))
         super(client: client)
-        @next_page = segments_url
+        @next_page_path = segments_path
         @data_attribute = 'segments'
       end
     end

--- a/lib/urbanairship/devices/sms.rb
+++ b/lib/urbanairship/devices/sms.rb
@@ -31,7 +31,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: channel_url('sms'),
+          path: channel_path('sms'),
           content_type: 'application/json'
         )
         logger.info("Registering SMS channel with msisdn #{@msisdn}")
@@ -55,7 +55,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'PUT',
           body: JSON.dump(payload),
-          url: channel_url('sms/' + channel_id),
+          path: channel_path('sms/' + channel_id),
           content_type: 'application/json'
         )
         logger.info("Updating SMS channel with msisdn #{@channel_id}")
@@ -74,7 +74,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: channel_url('sms/opt-out'),
+          path: channel_path('sms/opt-out'),
           content_type: 'application/json'
         )
         logger.info("Opting Out of SMS messages for #{@msisdn}")
@@ -93,7 +93,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: channel_url('sms/uninstall'),
+          path: channel_path('sms/uninstall'),
           content_type: 'application/json'
         )
         logger.info("Uninstalling SMS channel for #{@msisdn}")
@@ -106,7 +106,7 @@ module Urbanairship
 
         response = @client.send_request(
             method: 'GET',
-            url: channel_url('sms/' + @msisdn + '/' + @sender)
+            path: channel_path('sms/' + @msisdn + '/' + @sender)
         )
         logger.info { "Retrieved information for msisdn #{@msisdn}" }
         response

--- a/lib/urbanairship/devices/static_lists.rb
+++ b/lib/urbanairship/devices/static_lists.rb
@@ -22,7 +22,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: lists_url,
+          path: lists_path,
           content_type: 'application/json'
         )
         logger.info("Created static list for #{@name}")
@@ -35,7 +35,7 @@ module Urbanairship
           response = @client.send_request(
               method: 'PUT',
               body: csv_file,
-              url: lists_url(@name + '/csv/'),
+              path: lists_path(@name + '/csv/'),
               content_type: 'text/csv',
               encoding: gzip
           )
@@ -43,7 +43,7 @@ module Urbanairship
           response = @client.send_request(
               method: 'PUT',
               body: csv_file,
-              url: lists_url(@name + '/csv/'),
+              path: lists_path(@name + '/csv/'),
               content_type: 'text/csv'
           )
         end
@@ -61,7 +61,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'PUT',
           body: JSON.dump(payload),
-          url: lists_url(@name),
+          path: lists_path(@name),
           content_type: 'application/json'
         )
         logger.info("Updating the metadata for list #{@name}")
@@ -72,7 +72,7 @@ module Urbanairship
         fail ArgumentError, 'Name must be set' if name.nil?
         response = @client.send_request(
           method: 'GET',
-          url: lists_url(@name)
+          path: lists_path(@name)
         )
         logger.info("Retrieving info for list #{@name}")
         response
@@ -82,7 +82,7 @@ module Urbanairship
         fail ArgumentError, 'Name must be set' if name.nil?
         response = @client.send_request(
           method: 'DELETE',
-          url: lists_url(@name)
+          path: lists_path(@name)
         )
         logger.info("Deleted list #{@name}")
         response
@@ -92,7 +92,7 @@ module Urbanairship
     class StaticLists < Urbanairship::Common::PageIterator
       def initialize(client: required('client'))
         super(client: client)
-        @next_page = lists_url
+        @next_page_path = lists_path
         @data_attribute = 'lists'
       end
     end

--- a/lib/urbanairship/push/location.rb
+++ b/lib/urbanairship/push/location.rb
@@ -14,11 +14,11 @@ module Urbanairship
       def name_lookup(name: required('name'), type: nil)
         fail ArgumentError, 'name needs to be a string' unless name.is_a? String
         fail ArgumentError, 'type needs to be a string' unless type.nil? or type.is_a? String
-        url = location_url('?q=' + name)
-        url += '&type=' + type unless type.nil?
+        path = location_path('?q=' + name)
+        path += '&type=' + type unless type.nil?
         resp = @client.send_request(
           method: 'GET',
-          url: url
+          path: path
         )
         logger.info("Retrieved location information for #{name}")
         resp
@@ -28,11 +28,11 @@ module Urbanairship
         fail ArgumentError,
           'latitude and longitude need to be numbers' unless latitude.is_a? Numeric and longitude.is_a? Numeric
         fail ArgumentError, 'type needs to be a string' unless type.nil? or type.is_a? String
-        url = location_url(latitude.to_s + ',' + longitude.to_s)
-        url += '?type=' + type unless type.nil?
+        path = location_path(latitude.to_s + ',' + longitude.to_s)
+        path += '?type=' + type unless type.nil?
         resp = @client.send_request(
           method: 'GET',
-          url: url
+          path: path
         )
         logger.info("Retrieved location information for latitude #{latitude} and longitude #{longitude}")
         resp
@@ -45,11 +45,11 @@ module Urbanairship
            'lat1, long1, lat2, and long2 need to be numbers' unless lat1.is_a? Numeric and long2.is_a? Numeric\
            and lat2.is_a? Numeric and long2.is_a? Numeric
         fail ArgumentError, 'type needs to be a string' unless type.nil? or type.is_a? String
-        url = location_url(lat1.to_s + ',' + long1.to_s + ',' + lat2.to_s + ',' + long2.to_s)
-        url += '?type=' + type unless type.nil?
+        path = location_path(lat1.to_s + ',' + long1.to_s + ',' + lat2.to_s + ',' + long2.to_s)
+        path += '?type=' + type unless type.nil?
         resp = @client.send_request(
           method: 'GET',
-          url: url
+          path: path
         )
         logger.info("Retrieved location information for bounding box with lat1 #{lat1}, long1 #{long1}," +
           " lat2 #{lat2}, and long2 #{long2}")
@@ -58,20 +58,20 @@ module Urbanairship
 
       def alias_lookup(from_alias: required('from_alias'))
         fail ArgumentError, 'from_alias needs to be a string or an array of strings' unless from_alias.is_a? String or from_alias.is_a? Array
-        url = location_url('from-alias?')
+        path = location_path('from-alias?')
         if from_alias.is_a? Array
           from_alias.each do |a|
             fail ArgumentError, 'from_alias needs to be a string or an array of strings' unless a.is_a? String
-            url += a + '&'
+            path += a + '&'
           end
-          url = url.chop
+          path = path.chop
         else
-          url += from_alias
+          path += from_alias
         end
 
         resp = @client.send_request(
           method: 'GET',
-          url: url
+          path: path
         )
         logger.info("Retrieved location info from alias #{from_alias}")
         resp
@@ -81,10 +81,10 @@ module Urbanairship
         fail ArgumentError, 'polygon_id needs to be a string' unless polygon_id.is_a? String
         fail ArgumentError, 'zoom needs to be an integer' unless zoom.is_a? Integer
 
-        url = location_url(polygon_id + '?zoom=' + zoom.to_s)
+        path = location_path(polygon_id + '?zoom=' + zoom.to_s)
         resp = @client.send_request(
           method: 'GET',
-          url: url
+          path: path
         )
         logger.info("Retrieved location info for polygon #{polygon_id} and zoom level #{zoom}")
         resp

--- a/lib/urbanairship/push/location.rb
+++ b/lib/urbanairship/push/location.rb
@@ -93,7 +93,7 @@ module Urbanairship
       def date_ranges
         resp = @client.send_request(
           method: 'GET',
-          url: segments_url('dates/')
+          path: segments_path('dates/')
         )
         logger.info('Retrieved location date ranges')
         resp

--- a/lib/urbanairship/push/push.rb
+++ b/lib/urbanairship/push/push.rb
@@ -93,7 +93,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: schedules_url,
+          path: schedules_path,
           content_type: 'application/json'
         )
         pr = PushResponse.new(http_response_body: response['body'], http_response_code: response['code'].to_s)
@@ -170,7 +170,7 @@ module Urbanairship
            'schedule_id must be a string' unless schedule_id.is_a? String
         resp = @client.send_request(
           method: 'GET',
-          url: schedules_url(schedule_id)
+          path: schedules_path(schedule_id)
         )
         logger.info("Retrieved info for schedule_id #{schedule_id}")
         resp
@@ -181,7 +181,7 @@ module Urbanairship
     class ScheduledPushList < Urbanairship::Common::PageIterator
       def initialize(client: required('client'))
         super(client: client)
-        @next_page = schedules_url
+        @next_page_path = schedules_path
         @data_attribute = 'schedules'
       end
     end

--- a/lib/urbanairship/push/push.rb
+++ b/lib/urbanairship/push/push.rb
@@ -52,7 +52,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          url: push_url,
+          path: push_path,
           content_type: 'application/json'
         )
         pr = PushResponse.new(http_response_body: response['body'], http_response_code: response['code'].to_s)

--- a/lib/urbanairship/reports/response_statistics.rb
+++ b/lib/urbanairship/reports/response_statistics.rb
@@ -4,7 +4,7 @@ require 'time'
 module Urbanairship
   module Reports
     class Helper
-      def get_url(start_date, end_date, precision)
+      def get_period_params(start_date, end_date, precision)
         fail ArgumentError,
            'the parameters cannot be set to nil' if start_date.nil? or end_date.nil? or precision.nil?
         precision_array = %w(HOURLY DAILY MONTHLY)
@@ -98,8 +98,8 @@ module Urbanairship
       def initialize(client: required('client'), start_date: required('start_date'),
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
-        url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page_path = reports_path('optins/' + url)
+        period_params = Helper.new.get_period_params(start_date, end_date, precision)
+        @next_page_path = reports_path('optins/' + period_params)
         @data_attribute = 'optins'
       end
     end
@@ -108,8 +108,8 @@ module Urbanairship
       def initialize(client: required('client'), start_date: required('start_date'),
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
-        url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page_path = reports_path('optouts/' + url)
+        period_params = Helper.new.get_period_params(start_date, end_date, precision)
+        @next_page_path = reports_path('optouts/' + period_params)
         @data_attribute = 'optouts'
       end
     end
@@ -118,8 +118,8 @@ module Urbanairship
       def initialize(client: required('client'), start_date: required('start_date'),
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
-        url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page_path = reports_path('sends/' + url)
+        period_params = Helper.new.get_period_params(start_date, end_date, precision)
+        @next_page_path = reports_path('sends/' + period_params)
         @data_attribute = 'sends'
       end
     end
@@ -128,8 +128,8 @@ module Urbanairship
       def initialize(client: required('client'), start_date: required('start_date'),
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
-        url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page_path = reports_path('responses/' + url)
+        period_params = Helper.new.get_period_params(start_date, end_date, precision)
+        @next_page_path = reports_path('responses/' + period_params)
         @data_attribute = 'responses'
       end
     end
@@ -138,8 +138,8 @@ module Urbanairship
       def initialize(client: required('client'), start_date: required('start_date'),
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
-        url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page_path = reports_path('opens/' + url)
+        period_params = Helper.new.get_period_params(start_date, end_date, precision)
+        @next_page_path = reports_path('opens/' + period_params)
         @data_attribute = 'opens'
       end
     end
@@ -148,8 +148,8 @@ module Urbanairship
       def initialize(client: required('client'), start_date: required('start_date'),
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
-        url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page_path = reports_path('timeinapp/' + url)
+        period_params = Helper.new.get_period_params(start_date, end_date, precision)
+        @next_page_path = reports_path('timeinapp/' + period_params)
         @data_attribute = 'timeinapp'
       end
     end

--- a/lib/urbanairship/reports/response_statistics.rb
+++ b/lib/urbanairship/reports/response_statistics.rb
@@ -35,8 +35,8 @@ module Urbanairship
         fail ArgumentError,
            'push_id cannot be nil' if push_id.nil?
 
-        url = reports_url('responses/' + push_id)
-        response = @client.send_request(method: 'GET', url: url)
+        path = reports_path('responses/' + push_id)
+        response = @client.send_request(method: 'GET', path: path)
         logger.info("Retrieved info on push_id: #{push_id}")
         response
       end
@@ -60,10 +60,10 @@ module Urbanairship
           fail ArgumentError,
                'start_date and end_date must be valid date strings'
         end
-        url = reports_url('responses/list?start=' + start_parsed.iso8601 + '&end=' + end_parsed.iso8601)
-        url += '&limit' + limit.to_s unless limit.nil?
-        url += '&push_id_start&' + push_id_start unless push_id_start.nil?
-        @next_page = url
+        path = reports_path('responses/list?start=' + start_parsed.iso8601 + '&end=' + end_parsed.iso8601)
+        path += '&limit' + limit.to_s unless limit.nil?
+        path += '&push_id_start&' + push_id_start unless push_id_start.nil?
+        @next_page_path = path
         @data_attribute = 'pushes'
       end
     end
@@ -87,7 +87,7 @@ module Urbanairship
         end
         response = @client.send_request(
           method: 'GET',
-          url: reports_url('devices/?date=' + date_parsed.iso8601)
+          path: reports_path('devices/?date=' + date_parsed.iso8601)
         )
         logger.info("Retrieved device report for date #{date}")
         response
@@ -99,7 +99,7 @@ module Urbanairship
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
         url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page = reports_url('optins/' + url)
+        @next_page_path = reports_path('optins/' + url)
         @data_attribute = 'optins'
       end
     end
@@ -109,7 +109,7 @@ module Urbanairship
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
         url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page = reports_url('optouts/' + url)
+        @next_page_path = reports_path('optouts/' + url)
         @data_attribute = 'optouts'
       end
     end
@@ -119,7 +119,7 @@ module Urbanairship
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
         url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page = reports_url('sends/' + url)
+        @next_page_path = reports_path('sends/' + url)
         @data_attribute = 'sends'
       end
     end
@@ -129,7 +129,7 @@ module Urbanairship
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
         url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page = reports_url('responses/' + url)
+        @next_page_path = reports_path('responses/' + url)
         @data_attribute = 'responses'
       end
     end
@@ -139,7 +139,7 @@ module Urbanairship
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
         url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page = reports_url('opens/' + url)
+        @next_page_path = reports_path('opens/' + url)
         @data_attribute = 'opens'
       end
     end
@@ -149,7 +149,7 @@ module Urbanairship
                      end_date: required('end_date'), precision: required('precision'))
         super(client: client)
         url = Helper.new.get_url(start_date, end_date, precision)
-        @next_page = reports_url('timeinapp/' + url)
+        @next_page_path = reports_path('timeinapp/' + url)
         @data_attribute = 'timeinapp'
       end
     end

--- a/lib/urbanairship/reports/response_statistics.rb
+++ b/lib/urbanairship/reports/response_statistics.rb
@@ -5,21 +5,32 @@ module Urbanairship
   module Reports
     class Helper
       def get_period_params(start_date, end_date, precision)
-        fail ArgumentError,
-           'the parameters cannot be set to nil' if start_date.nil? or end_date.nil? or precision.nil?
-        precision_array = %w(HOURLY DAILY MONTHLY)
-        fail ArgumentError,
-             "Precision must be 'HOURLY', 'DAILY', or 'MONTHLY'" unless precision_array.include?(precision)
+        validates_parameters_presence!(start_date, end_date, precision)
+        validates_precision_format!(precision)
 
         begin
-          start_parsed = Time.parse(start_date)
-          end_parsed = Time.parse(end_date)
+          start_parsed = Time.parse(start_date).iso8601
+          end_parsed = Time.parse(end_date).iso8601
+
+          "?start=#{start_parsed}&end=#{end_parsed}&precision=#{precision}"
         rescue ArgumentError
-          fail ArgumentError,
-             'start_date and end_date must be valid date strings'
+          fail ArgumentError, 'start_date and end_date must be valid date strings'
         end
-        url = '?start=' + start_parsed.iso8601 + '&end=' + end_parsed.iso8601
-        url += '&precision=' + precision
+      end
+
+      private
+
+      def validates_parameters_presence!(start_date, end_date, precision)
+        return unless [start_date, end_date, precision].any?(&:nil?)
+
+        fail ArgumentError, 'the parameters cannot be set to nil'
+      end
+
+      AUTHORIZED_PRECISIONS = %w(HOURLY DAILY MONTHLY)
+      def validates_precision_format!(precision)
+        return if AUTHORIZED_PRECISIONS.include?(precision)
+
+        fail ArgumentError, 'Precision must be "HOURLY", "DAILY", or "MONTHLY"'
       end
     end
 

--- a/spec/lib/urbanairship/client_spec.rb
+++ b/spec/lib/urbanairship/client_spec.rb
@@ -9,6 +9,22 @@ describe Urbanairship::Client do
     expect(ua_client).not_to be_nil
   end
 
+  it 'lets you override the default server' do
+    overriden_server = 'my.custom.server'
+    path = '/path-to_paradise'
+
+    mock_response = double('response')
+    allow(mock_response).to receive_messages(code: 200, headers: '', body: '{}')
+
+    expect(RestClient::Request)
+      .to(receive(:execute)
+        .with(hash_including({ url: "https://#{overriden_server}/api#{path}" })))
+          .and_return(mock_response)
+
+    ua_client = UA::Client.new(key: '123', secret: 'abc', server: overriden_server)
+    ua_client.send_request(method: 'POST', path: path)
+  end
+
   it 'lets you specify the url directly' do
     url = 'https://www.airship.com/'
     mock_response = double('response')

--- a/spec/lib/urbanairship/client_spec.rb
+++ b/spec/lib/urbanairship/client_spec.rb
@@ -9,6 +9,34 @@ describe Urbanairship::Client do
     expect(ua_client).not_to be_nil
   end
 
+  it 'lets you specify the url directly' do
+    url = 'https://www.airship.com/'
+    mock_response = double('response')
+    allow(mock_response).to(receive_messages(code: 200, headers: '', body: '{}'))
+
+    expect(RestClient::Request)
+      .to(receive(:execute)
+        .with(hash_including({ url: url })))
+          .and_return(mock_response)
+
+    ua_client = UA::Client.new(key: '123', secret: 'abc')
+    ua_client.send_request(method: 'POST', url: url)
+  end
+
+  it 'lets you specify the url with a path' do
+    path = '/some-path'
+    mock_response = double('response')
+    allow(mock_response).to(receive_messages(code: 200, headers: '', body: '{}'))
+
+    expect(RestClient::Request)
+      .to(receive(:execute)
+        .with(hash_including({ url: "https://#{UA.configuration.server}/api#{path}" })))
+          .and_return(mock_response)
+
+    ua_client = UA::Client.new(key: '123', secret: 'abc')
+    ua_client.send_request(method: 'POST', path: path)
+  end
+
   it 'uses basic auth' do
     mock_response = double('response')
     allow(mock_response).to(receive_messages(code: 200, headers: '', body: '{}'))

--- a/spec/lib/urbanairship/client_spec.rb
+++ b/spec/lib/urbanairship/client_spec.rb
@@ -53,6 +53,13 @@ describe Urbanairship::Client do
     ua_client.send_request(method: 'POST', path: path)
   end
 
+  it 'raises an error if both path and url are nil' do
+    ua_client = UA::Client.new(key: '123', secret: 'abc')
+
+    expect { ua_client.send_request(method: 'POST') }
+      .to raise_error(ArgumentError, "path and url can't be both nil")
+  end
+
   it 'uses basic auth' do
     mock_response = double('response')
     allow(mock_response).to(receive_messages(code: 200, headers: '', body: '{}'))

--- a/spec/lib/urbanairship/client_spec.rb
+++ b/spec/lib/urbanairship/client_spec.rb
@@ -44,7 +44,7 @@ describe Urbanairship::Client do
                                .and_return(mock_response)
 
     ua_client = UA::Client.new(key: '123', secret: 'abc')
-    ua_client.send_request(method: 'POST', url: UA.channel_url)
+    ua_client.send_request(method: 'POST', path: UA.channel_path)
   end
 
   it 'uses bearer auth' do
@@ -59,6 +59,6 @@ describe Urbanairship::Client do
                                .and_return(mock_response)
 
     ua_client = UA::Client.new(key: '123', secret: 'abc', token: 'test-token')
-    ua_client.send_request(method: 'POST', url: UA.channel_url, auth_type: :bearer)
+    ua_client.send_request(method: 'POST', path: UA.channel_path, auth_type: :bearer)
   end
 end

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -7,7 +7,7 @@ describe Urbanairship::Common do
   end
 
   it 'has a SEGMENTS_URL' do
-    expect(Urbanairship.segments_url).not_to be nil
+    expect(Urbanairship.segments_path).not_to be nil
   end
 
   it 'has a CHANNEL_URL' do

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -15,56 +15,79 @@ describe Urbanairship::Common do
   end
 
   describe Urbanairship::Common::PageIterator do
-    UA = Urbanairship
-    airship = UA::Client.new(key: '123', secret: 'abc')
-    page_iterator = UA::Common::PageIterator.new(client: airship)
-    page_iterator.data_attribute = :data_attr
-    expected_first_list = {
-      'body' => {
-        :data_attr => [
-          {
-            :prop1 => 'propertyA',
-            :prop2 => 'propertyB',
-            :prop3 => 'propertyC'
-          },
-          {
-            :prop1 => 'propertyD',
-            :prop2 => 'propertyE',
-            :prop3 => 'propertyF'
-          }
-        ],
-        'next_page' => 'next_url'
-      },
-      'code' => 200
-    }
+    let(:my_iterator_class) do
+      Class.new(Urbanairship::Common::PageIterator) do
+        def initialize(client: required('client'), data_attr:, next_page:)
+          super(client: client)
 
-    expected_second_list = {
+          @data_attribute = data_attr
+          @next_page = next_page
+        end
+      end
+    end
+    let(:client) { Urbanairship::Client.new(key: '123', secret: 'abc') }
+    let(:data_attr) { 'data_attr' }
+    let(:second_url) { "https://#{Urbanairship.configuration.server}/api/page-1" }
+    let(:first_response) do
+      {
         'body' => {
-          :data_attr => [
-            {
-              :prop1 => 'propertyG',
-              :prop2 => 'propertyH',
-              :prop3 => 'propertyI'
-            }
-          ]
+          'data_attr' => [data_attr_1, data_attr_2],
+          'next_page' => second_url
         },
         'code' => 200
-    }
-    it 'can iterate through pages' do
-      allow(airship).to receive(:send_request).and_return(expected_first_list, expected_second_list)
-      finished_list = Array.new
-      page_iterator.load_page
+      }
+    end
+    let(:second_response) do
+      {
+        'body' => {
+          'data_attr' => [data_attr_3]
+        },
+        'code' => 200
+      }
+    end
+    let(:data_attr_1) do
+      {
+        'prop1' => 'propertyA',
+        'prop2' => 'propertyB',
+        'prop3' => 'propertyC'
+      }
+    end
+    let(:data_attr_2) do
+      {
+        'prop1' => 'propertyD',
+        'prop2' => 'propertyE',
+        'prop3' => 'propertyF'
+      }
+    end
+    let(:data_attr_3) do
+      {
+        'prop1' => 'propertyG',
+        'prop2' => 'propertyH',
+        'prop3' => 'propertyI'
+      }
+    end
 
-      page_iterator.each do |value|
-        finished_list.push(value)
+    context 'with @next_page defined' do
+      let(:my_iterator) do
+        my_iterator_class.new(client: client, data_attr: data_attr, next_page: first_url)
       end
+      let(:first_url) { "https://#{Urbanairship.configuration.server}/api/page-0" }
 
-      obj_list = %w(propertyI propertyH propertyG propertyF propertyE propertyD propertyC propertyB propertyA)
+      it 'iterates through pages' do
+        allow(client)
+          .to receive(:send_request)
+            .with({ method: 'GET', url: first_url })
+              .and_return(first_response)
+        allow(client)
+          .to receive(:send_request)
+            .with({ method: 'GET', url: second_url })
+              .and_return(second_response)
 
-      finished_list.each do |value|
-        expect(value[:prop1]).to eq(obj_list.pop)
-        expect(value[:prop2]).to eq(obj_list.pop)
-        expect(value[:prop3]).to eq(obj_list.pop)
+        finished_list = []
+        my_iterator.each { |value| finished_list.push(value) }
+
+        expect(finished_list).to eq([data_attr_1, data_attr_2, data_attr_3])
+        expect(my_iterator.count).to eq(3)
       end
     end
   end

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -21,8 +21,8 @@ describe Urbanairship::Common do
           super(client: client)
 
           @data_attribute = data_attr
-          @next_page_url = next_page_url
           @next_page_path = next_page_path
+          @next_page_url = next_page_url
         end
       end
     end

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -41,7 +41,8 @@ describe Urbanairship::Common do
     let(:second_response) do
       {
         'body' => {
-          'data_attr' => [data_attr_3]
+          'data_attr' => [data_attr_3],
+          'next_page' => third_url
         },
         'code' => 200
       }
@@ -73,6 +74,16 @@ describe Urbanairship::Common do
         my_iterator_class.new(client: client, data_attr: data_attr, next_page: first_url)
       end
       let(:first_url) { "https://#{Urbanairship.configuration.server}/api/page-0" }
+      let(:third_url) { "https://#{Urbanairship.configuration.server}/api/page-2" }
+      let(:third_response) do
+        {
+          'body' => {
+            'data_attr' => [data_attr_3],
+            'next_page' => third_url
+          },
+          'code' => 200
+        }
+      end
 
       it 'iterates through pages' do
         allow(client)
@@ -83,6 +94,10 @@ describe Urbanairship::Common do
           .to receive(:send_request)
             .with({ method: 'GET', url: second_url })
               .and_return(second_response)
+        allow(client)
+          .to receive(:send_request)
+            .with({ method: 'GET', url: third_url })
+              .and_return(third_response)
 
         finished_list = []
         my_iterator.each { |value| finished_list.push(value) }
@@ -97,6 +112,7 @@ describe Urbanairship::Common do
         my_iterator_class.new(client: client, data_attr: data_attr, next_page_path: first_path)
       end
       let(:first_path) { "/page-0" }
+      let(:third_url) { nil }
 
       it 'iterates through pages' do
         allow(client)

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -17,11 +17,12 @@ describe Urbanairship::Common do
   describe Urbanairship::Common::PageIterator do
     let(:my_iterator_class) do
       Class.new(Urbanairship::Common::PageIterator) do
-        def initialize(client: required('client'), data_attr:, next_page:)
+        def initialize(client: required('client'), data_attr:, next_page: nil, next_page_path: nil)
           super(client: client)
 
           @data_attribute = data_attr
           @next_page = next_page
+          @next_page_path = next_page_path
         end
       end
     end

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -91,5 +91,29 @@ describe Urbanairship::Common do
         expect(my_iterator.count).to eq(3)
       end
     end
+
+    context 'with @next_page_path defined' do
+      let(:my_iterator) do
+        my_iterator_class.new(client: client, data_attr: data_attr, next_page_path: first_path)
+      end
+      let(:first_path) { "/page-0" }
+
+      it 'iterates through pages' do
+        allow(client)
+          .to receive(:send_request)
+            .with({ method: 'GET', path: first_path })
+              .and_return(first_response)
+        allow(client)
+          .to receive(:send_request)
+            .with({ method: 'GET', url: second_url })
+              .and_return(second_response)
+
+        finished_list = []
+        my_iterator.each { |value| finished_list.push(value) }
+
+        expect(finished_list).to eq([data_attr_1, data_attr_2, data_attr_3])
+        expect(my_iterator.count).to eq(3)
+      end
+    end
   end
 end

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -11,7 +11,7 @@ describe Urbanairship::Common do
   end
 
   it 'has a CHANNEL_URL' do
-    expect(Urbanairship.channel_url).not_to be nil
+    expect(Urbanairship.channel_path).not_to be nil
   end
 
   describe Urbanairship::Common::PageIterator do

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -17,11 +17,11 @@ describe Urbanairship::Common do
   describe Urbanairship::Common::PageIterator do
     let(:my_iterator_class) do
       Class.new(Urbanairship::Common::PageIterator) do
-        def initialize(client: required('client'), data_attr:, next_page: nil, next_page_path: nil)
+        def initialize(client: required('client'), data_attr:, next_page_url: nil, next_page_path: nil)
           super(client: client)
 
           @data_attribute = data_attr
-          @next_page = next_page
+          @next_page_url = next_page_url
           @next_page_path = next_page_path
         end
       end
@@ -69,9 +69,9 @@ describe Urbanairship::Common do
       }
     end
 
-    context 'with @next_page defined' do
+    context 'with @next_page_url defined' do
       let(:my_iterator) do
-        my_iterator_class.new(client: client, data_attr: data_attr, next_page: first_url)
+        my_iterator_class.new(client: client, data_attr: data_attr, next_page_url: first_url)
       end
       let(:first_url) { "https://#{Urbanairship.configuration.server}/api/page-0" }
       let(:third_url) { "https://#{Urbanairship.configuration.server}/api/page-2" }

--- a/spec/lib/urbanairship/common_spec.rb
+++ b/spec/lib/urbanairship/common_spec.rb
@@ -3,7 +3,7 @@ require 'urbanairship'
 
 describe Urbanairship::Common do
   it 'has a PUSH_URL' do
-    expect(Urbanairship.push_url).not_to be nil
+    expect(Urbanairship.push_path).not_to be nil
   end
 
   it 'has a SEGMENTS_URL' do

--- a/spec/lib/urbanairship/custom_events/custom_events_spec.rb
+++ b/spec/lib/urbanairship/custom_events/custom_events_spec.rb
@@ -93,7 +93,7 @@ describe Urbanairship::CustomEvents::CustomEvent do
           body: JSON.dump(expected_payload),
           content_type: 'application/json',
           method: 'POST',
-          url: UA.custom_events_url
+          path: UA.custom_events_path
         )
         .and_return(ua_http_response)
 


### PR DESCRIPTION
### What does this do and why?
Users having to deal with multiple Airship servers (EU/US) on the same machine can't use this gem since you can only configure the server globally, not on a request-basis.

This PR adds this functionality by adding a new optional `server` parameter to the `Client` initializer.

### Additional notes for reviewers
* **No breaking change for current users of the Gem**
* One of the existing specs wasn't testing anything: it's been fixed
* Please read commit by commit, otherwise it will be complicated to follow

Here is a description of the commits to help you review the PR:

1. I've added some specs on `Client` and `PageIterator` to prepare my refactoring
2. To prepare my next change, I've refactored `PageIterator` to improve readability
3. I've added a new `next_page_path` attribute to `PageIterator` which permits initialising the iteration with a "path" instead of an "url" (preparation for the next commits)
4. I've changed all the `xxx_url` methods into `xxx_path`
5. Small refactoring on a misleading method name
6. Finally, add the optional `server` parameter to the Client initializer ✌️ 
7. Bonus: fixed highlights of the README

### Testing
- I wrote tests covering these changes
- I've tested for Ruby version 2.6.0


### Airship Contribution Agreement

- I've filled out and signed Airship's contribution agreement form.

