### PR TITLE
Add missing "require"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ Simple Tag Push
 
 Specify the Airship server used to make your requests
 -----------------------------------------------------
-By default, the request will be sent to the 'go.airship.us' server:
+By default, the request will be sent to the 'go.urbanairship.com' server:
 
 .. code-block:: ruby
 
@@ -172,9 +172,9 @@ Finally, you can change the targeted server on a request basis:
      config.server = 'go.airship.eu'
    end
 
-   Urbanairship::Client.new(key:'application_key', secret:'master_secret', server: 'go.airship.us')
+   Urbanairship::Client.new(key:'application_key', secret:'master_secret', server: 'go.urbanairship.com')
    # The Urbanairship configuration is overridden by the client and the
-   # request will be sent to the 'go.airship.us' server
+   # request will be sent to the 'go.urbanairship.com' server
 
 Contributing
 ============

--- a/lib/urbanairship.rb
+++ b/lib/urbanairship.rb
@@ -1,3 +1,4 @@
+require 'urbanairship/custom_events/custom_event'
 require 'urbanairship/custom_events/payload'
 require 'urbanairship/push/audience'
 require 'urbanairship/push/payload'


### PR DESCRIPTION
### What does this do and why?
Add missing `require`, which was leading to a `uninitialized constant Urbanairship::CustomEvents::CustomEvent` exception.


### Testing
I've tested for Ruby versions 2.6.0

### Airship Contribution Agreement
I've filled out and signed Airship's contribution agreement form.
