### PR TITLE
Adjust header names

### DIFF
--- a/lib/urbanairship/client.rb
+++ b/lib/urbanairship/client.rb
@@ -52,9 +52,9 @@ module Urbanairship
 
         raise ArgumentError.new("path and url can't be both nil") if path.nil? && url.nil?
 
-        headers = {'User-agent' => 'UARubyLib/' + Urbanairship::VERSION}
+        headers = {'User-Agent' => 'UARubyLib/' + Urbanairship::VERSION}
         headers['Accept'] = 'application/vnd.urbanairship+json; version=3'
-        headers['Content-type'] = content_type unless content_type.nil?
+        headers['Content-Type'] = content_type unless content_type.nil?
         headers['Content-Encoding'] = encoding unless encoding.nil?
 
         if auth_type == :bearer


### PR DESCRIPTION
### What does this do and why?
This pull request adjusts the http header names passed to `rest-client`. These now match `rest-client` so `Net::HTTP` won't complain with the warning `warning: net/http: duplicated HTTP header: User-agent` anymore.
