### PR TITLE
Fix bad `associate` endpoint, add test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 2.2.5
   - 2.3.1
+  - 2.7.2

--- a/lib/urbanairship/devices/named_user.rb
+++ b/lib/urbanairship/devices/named_user.rb
@@ -20,7 +20,7 @@ module Urbanairship
         payload = {}
         payload['channel_id'] = channel_id
         payload['device_type'] = device_type unless device_type.nil?
-        payload['named_user_id'] = @named_user_id
+        payload['named_user_id'] = @named_user_id&.to_s
 
         response = @client.send_request(
           method: 'POST',

--- a/lib/urbanairship/devices/named_user.rb
+++ b/lib/urbanairship/devices/named_user.rb
@@ -25,7 +25,7 @@ module Urbanairship
         response = @client.send_request(
           method: 'POST',
           body: JSON.dump(payload),
-          path: named_users_path('/associate'),
+          path: named_users_path('associate'),
           content_type: 'application/json'
         )
         logger.info { "Associated channel_id #{channel_id} with named_user #{@named_user_id}" }

--- a/lib/urbanairship/devices/named_user.rb
+++ b/lib/urbanairship/devices/named_user.rb
@@ -20,7 +20,7 @@ module Urbanairship
         payload = {}
         payload['channel_id'] = channel_id
         payload['device_type'] = device_type unless device_type.nil?
-        payload['named_user_id'] = @named_user_id&.to_s
+        payload['named_user_id'] = @named_user_id.to_s
 
         response = @client.send_request(
           method: 'POST',

--- a/spec/lib/urbanairship/devices/named_user_spec.rb
+++ b/spec/lib/urbanairship/devices/named_user_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 require 'urbanairship'
 
-
 describe Urbanairship::Devices do
   UA = Urbanairship
   airship = UA::Client.new(key: '123', secret: 'abc')
+  let(:channel_id) { '123' }
+  let(:device_type) { 'android' }
+  let(:named_user_id) { 'user' }
 
   describe Urbanairship::Devices::NamedUser do
     expected_resp = {
@@ -17,6 +19,19 @@ describe Urbanairship::Devices do
     named_user.named_user_id = 'user'
 
     describe '#associate' do
+      it 'makes the expected request' do
+        allow(airship).to receive(:send_request) do |arguments|
+          expect(arguments).to eq(
+            method: 'POST',
+            body: { channel_id: channel_id, device_type: device_type, named_user_id: named_user_id }.to_json,
+            path: "/named_users/associate",
+            content_type: "application/json",
+          )
+          expected_resp
+        end
+        named_user.associate(channel_id: channel_id, device_type: device_type)
+      end
+
       it 'associates a channel with a named_user' do
         allow(airship).to receive(:send_request).and_return(expected_resp)
         actual_resp = named_user.associate(channel_id:'123', device_type:'android')


### PR DESCRIPTION
**If you want your PR addressed quickly, please also reach out to our [support team](https://support.airship.com/)
so we can understand when you need it reviewed and how it is impacting your use of our services.** We also generally
will not release new versions of our library without new feature support, a bug fix, or a clear reason from a customer
why an update is required to minimize how often other customers need to update.

### What does this do and why?
* Fixes the URL used by the associate endpoint. It currently adds a double slash which results in an error. Added missing test coverage for this
* Cast `named_user_id` to a string in **associate** endpoint so users can pass in internal IDs

### Additional notes for reviewers
Ticker 77316 on your internal systems

### Testing
- [x] If these changes added new functionality, I tested them against the live API with real auth
- [x] I wrote tests covering these changes

* I've tested for Ruby versions:

- [x] 2.2.5
- [x] 2.3.1
- [x] Ruby 2.7.2. The above versions are very old.
See test output here https://travis-ci.com/github/OLIOEX/ruby-library/builds/231341049

### Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed Airship's contribution agreement form.

### Screenshots
* If applicable
