### PR TITLE
fix: Ruby Compatibility Fixes for API Client

### DIFF
--- a/lib/urbanairship/common.rb
+++ b/lib/urbanairship/common.rb
@@ -190,7 +190,7 @@ module Urbanairship
             path: @next_page_path,
             url: @next_page_url
           }.select { |k, v| !v.nil? }
-        response = @client.send_request(params)
+        response = @client.send_request(**params)
 
         @data_list = get_new_data(response)
         @next_page_url = get_next_page_url(response)

--- a/spec/lib/urbanairship/devices/named_user_spec.rb
+++ b/spec/lib/urbanairship/devices/named_user_spec.rb
@@ -299,8 +299,24 @@ describe Urbanairship::Devices do
     }
 
     it 'iterates correctly through a response' do
-      allow(airship).to receive(:send_request).and_return(expected_response, expected_next_resp)
-      named_user_list = UA::NamedUserList.new(client:airship)
+      # Create response objects that match what RestClient would return
+      first_response = double('RestClient::Response',
+        code: 200,
+        body: expected_response['body'].to_json,
+        headers: {'Content-Type' => 'application/json'}
+      )
+      second_response = double('RestClient::Response',
+        code: 200,
+        body: expected_next_resp['body'].to_json,
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+      # Stub RestClient to return our responses
+      allow(RestClient::Request).to receive(:execute)
+        .with(hash_including(method: 'GET'))
+        .and_return(first_response, second_response)
+
+      named_user_list = UA::NamedUserList.new(client: airship)
       instantiated_list = Array.new
       named_user_list.each do |named_user|
         expect(named_user).to eq(named_user_item)

--- a/spec/lib/urbanairship/push/audience_spec.rb
+++ b/spec/lib/urbanairship/push/audience_spec.rb
@@ -54,7 +54,12 @@ describe Urbanairship do
       ],
       [
         :tag,
-        ['test', group: 'test-group'],
+        'test',
+        { tag: 'test' }
+      ],
+      [
+        :tag,
+        ['test', { group: 'test-group' }],
         { tag: 'test', group: 'test-group' }
       ],
       [
@@ -74,7 +79,12 @@ describe Urbanairship do
       ]
     ].each do |selector, value, expected_result|
       it "can filter for '#{selector}'" do
-        actual_payload = UA.send(selector, *value)
+        if selector == :tag && value.is_a?(Array) && value[1].is_a?(Hash)
+          tag_value, options = value
+          actual_payload = UA.send(selector, tag_value, **options)
+        else
+          actual_payload = UA.send(selector, *value)
+        end
         expect(actual_payload).to eq expected_result
       end
     end


### PR DESCRIPTION
### What does this do and why?
Ruby Compatibility Fixes for API Client

This PR addresses two Ruby compatibility issues in the Urbanairship API client:

1. PageIterator Keyword Arguments
    - Fixed the `send_request` invocation in `PageIterator#load_page` to properly handle keyword arguments using the double splat operator (`**`)
    - This ensures the API client works correctly with newer Ruby versions while maintaining backward compatibility

2. Tag Selector Test Updates
    - Updated the tag selector tests to properly handle keyword arguments when testing tag groups
    - Fixed test cases to correctly pass both tag value and group options using explicit keyword argument syntax

All tests are now passing with these changes. The updates maintain the existing API behavior while ensuring compatibility with modern Ruby versions.

### Testing
- [ ] If these changes added new functionality, I tested them against the live API with real auth
- [x] I wrote tests covering these changes

* I've tested for Ruby versions:

- [ ] 2.6.7
- [ ] 2.7.3

### Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed Airship's contribution agreement form.

### Screenshots
* If applicable
